### PR TITLE
Make EncodedBase64 and URLEncodedBase64 distinct types

### DIFF
--- a/Sources/WebAuthn/Ceremonies/Authentication/PublicKeyCredentialRequestOptions.swift
+++ b/Sources/WebAuthn/Ceremonies/Authentication/PublicKeyCredentialRequestOptions.swift
@@ -16,7 +16,7 @@ import Foundation
 
 /// The `PublicKeyCredentialRequestOptions` gets passed to the WebAuthn API (`navigator.credentials.get()`)
 public struct PublicKeyCredentialRequestOptions: Codable {
-    public let challenge: String
+    public let challenge: EncodedBase64
     public let timeout: TimeInterval?
     public let rpId: String?
     public let allowCredentials: [PublicKeyCredentialDescriptor]?

--- a/Sources/WebAuthn/Ceremonies/Registration/AuthenticatorAttestationResponse.swift
+++ b/Sources/WebAuthn/Ceremonies/Registration/AuthenticatorAttestationResponse.swift
@@ -28,14 +28,14 @@ struct ParsedAuthenticatorAttestationResponse {
 
     init(from rawResponse: AuthenticatorAttestationResponse) throws {
         // assembling clientData
-        guard let clientDataJSONData = rawResponse.clientDataJSON.base64URLDecodedData else {
+        guard let clientDataJSONData = rawResponse.clientDataJSON.urlDecoded.decoded else {
             throw WebAuthnError.invalidClientDataJSON
         }
         let clientData = try JSONDecoder().decode(CollectedClientData.self, from: clientDataJSONData)
         self.clientData = clientData
 
         // Step 11. (assembling attestationObject)
-        guard let attestationObjectData = rawResponse.attestationObject.base64URLDecodedData,
+        guard let attestationObjectData = rawResponse.attestationObject.urlDecoded.decoded,
             let decodedAttestationObject = try CBOR.decode([UInt8](attestationObjectData)) else {
             throw WebAuthnError.invalidAttestationObject
         }

--- a/Sources/WebAuthn/Ceremonies/Registration/RegistrationCredential.swift
+++ b/Sources/WebAuthn/Ceremonies/Registration/RegistrationCredential.swift
@@ -44,7 +44,7 @@ struct ParsedCredentialCreationResponse {
     init(from rawResponse: RegistrationCredential) throws {
         id = rawResponse.id
 
-        guard let decodedRawID = rawResponse.rawID.base64URLDecodedData else {
+        guard let decodedRawID = rawResponse.rawID.urlDecoded.decoded else {
             throw WebAuthnError.invalidRawID
         }
         rawID = decodedRawID
@@ -72,7 +72,7 @@ struct ParsedCredentialCreationResponse {
         )
 
         // Step 10.
-        guard let clientData = raw.clientDataJSON.string.data(using: .utf8) else {
+        guard let clientData = raw.clientDataJSON.asData() else {
             throw WebAuthnError.invalidClientDataJSON
         }
         let hash = SHA256.hash(data: clientData)

--- a/Sources/WebAuthn/Ceremonies/Registration/RegistrationCredential.swift
+++ b/Sources/WebAuthn/Ceremonies/Registration/RegistrationCredential.swift
@@ -72,7 +72,7 @@ struct ParsedCredentialCreationResponse {
         )
 
         // Step 10.
-        guard let clientData = raw.clientDataJSON.data(using: .utf8) else {
+        guard let clientData = raw.clientDataJSON.string.data(using: .utf8) else {
             throw WebAuthnError.invalidClientDataJSON
         }
         let hash = SHA256.hash(data: clientData)

--- a/Sources/WebAuthn/Helpers/Base64Utilities.swift
+++ b/Sources/WebAuthn/Helpers/Base64Utilities.swift
@@ -15,35 +15,12 @@
 import Foundation
 import Logging
 
-/// Container for URL encoded base64 data
-public struct URLEncodedBase64: ExpressibleByStringLiteral, Codable, Hashable {
-    let string: String
-
-    public init(_ string: String) {
-        self.string = string
-    }
-
-    public init(stringLiteral value: StringLiteralType) {
-        self.init(value)
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        self.string = try container.decode(String.self)
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        try container.encode(self.string)
-    }
-}
-
 /// Container for base64 encoded data
 public struct EncodedBase64: ExpressibleByStringLiteral, Codable, Hashable {
-    let string: String
+    private let base64: String
 
     public init(_ string: String) {
-        self.string = string
+        self.base64 = string
     }
 
     public init(stringLiteral value: StringLiteralType) {
@@ -52,24 +29,87 @@ public struct EncodedBase64: ExpressibleByStringLiteral, Codable, Hashable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        self.string = try container.decode(String.self)
+        self.base64 = try container.decode(String.self)
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
-        try container.encode(self.string)
+        try container.encode(self.base64)
+    }
+
+    /// Return as URL encoded base64
+    public var urlEncoded: URLEncodedBase64 {
+        return .init(
+            self.base64.replacingOccurrences(of: "+", with: "-")
+                .replacingOccurrences(of: "/", with: "_")
+                .replacingOccurrences(of: "=", with: "")
+        )
+    }
+
+    /// Return base64 decoded data
+    public var decoded: Data? {
+        return Data(base64Encoded: self.base64)
+    }
+
+    /// return Base64 data as a String
+    public func asString() -> String {
+        return self.base64
+    }
+
+    /// return Base64 data as Data
+    public func asData() -> Data? {
+        return self.base64.data(using: .utf8)
     }
 }
 
-//public typealias URLEncodedBase64 = String
-//public typealias EncodedBase64 = String
+/// Container for URL encoded base64 data
+public struct URLEncodedBase64: ExpressibleByStringLiteral, Codable, Hashable {
+    let base64: String
+
+    public init(_ string: String) {
+        self.base64 = string
+    }
+
+    public init(stringLiteral value: StringLiteralType) {
+        self.init(value)
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.base64 = try container.decode(String.self)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.base64)
+    }
+
+    /// Return URL decoded Base64 data
+    public var urlDecoded: EncodedBase64 {
+        var result = self.base64.replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
+        while result.count % 4 != 0 {
+            result = result.appending("=")
+        }
+        return .init(result)
+    }
+
+    /// return Base64 data as a String
+    public func asString() -> String {
+        return self.base64
+    }
+
+    /// return Base64 data as Data
+    public func asData() -> Data? {
+        return self.base64.data(using: .utf8)
+    }
+}
 
 extension Array where Element == UInt8 {
     /// Encodes an array of bytes into a base64url-encoded string
     /// - Returns: A base64url-encoded string
     public func base64URLEncodedString() -> URLEncodedBase64 {
         let base64String = Data(bytes: self, count: self.count).base64EncodedString()
-        return String.base64URL(fromBase64: .init(base64String))
+        return EncodedBase64(base64String).urlEncoded
     }
 
     /// Encodes an array of bytes into a base64 string
@@ -88,33 +128,7 @@ extension Data {
 }
 
 extension String {
-    /// Decode a base64url-encoded `String` to a base64 `String`
-    /// - Returns: A base64-encoded `String`
-    public static func base64(fromBase64URLEncoded base64URLEncoded: URLEncodedBase64) -> EncodedBase64 {
-        return .init(
-            base64URLEncoded.string.replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
-        )
-    }
-
-    public static func base64URL(fromBase64 base64Encoded: EncodedBase64) -> URLEncodedBase64 {
-        return .init(
-            base64Encoded.string.replacingOccurrences(of: "+", with: "-")
-                .replacingOccurrences(of: "/", with: "_")
-                .replacingOccurrences(of: "=", with: "")
-        )
-    }
-
     func toBase64() -> EncodedBase64 {
         return .init(Data(self.utf8).base64EncodedString())
-    }
-}
-
-extension URLEncodedBase64 {
-    public var base64URLDecodedData: Data? {
-        var result = self.string.replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
-        while result.count % 4 != 0 {
-            result = result.appending("=")
-        }
-        return Data(base64Encoded: result)
     }
 }

--- a/Sources/WebAuthn/Helpers/Base64Utilities.swift
+++ b/Sources/WebAuthn/Helpers/Base64Utilities.swift
@@ -15,28 +15,74 @@
 import Foundation
 import Logging
 
-public typealias URLEncodedBase64 = String
-public typealias EncodedBase64 = String
+/// Container for URL encoded base64 data
+public struct URLEncodedBase64: ExpressibleByStringLiteral, Codable, Hashable {
+    let string: String
+
+    public init(_ string: String) {
+        self.string = string
+    }
+
+    public init(stringLiteral value: StringLiteralType) {
+        self.init(value)
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.string = try container.decode(String.self)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.string)
+    }
+}
+
+/// Container for base64 encoded data
+public struct EncodedBase64: ExpressibleByStringLiteral, Codable, Hashable {
+    let string: String
+
+    public init(_ string: String) {
+        self.string = string
+    }
+
+    public init(stringLiteral value: StringLiteralType) {
+        self.init(value)
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.string = try container.decode(String.self)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.string)
+    }
+}
+
+//public typealias URLEncodedBase64 = String
+//public typealias EncodedBase64 = String
 
 extension Array where Element == UInt8 {
     /// Encodes an array of bytes into a base64url-encoded string
     /// - Returns: A base64url-encoded string
-    public func base64URLEncodedString() -> String {
+    public func base64URLEncodedString() -> URLEncodedBase64 {
         let base64String = Data(bytes: self, count: self.count).base64EncodedString()
-        return String.base64URL(fromBase64: base64String)
+        return String.base64URL(fromBase64: .init(base64String))
     }
 
     /// Encodes an array of bytes into a base64 string
     /// - Returns: A base64-encoded string
-    public func base64EncodedString() -> String {
-        return Data(bytes: self, count: self.count).base64EncodedString()
+    public func base64EncodedString() -> EncodedBase64 {
+        return .init(Data(bytes: self, count: self.count).base64EncodedString())
     }
 }
 
 extension Data {
     /// Encodes data into a base64url-encoded string
     /// - Returns: A base64url-encoded string
-    public func base64URLEncodedString() -> String {
+    public func base64URLEncodedString() -> URLEncodedBase64 {
         return [UInt8](self).base64URLEncodedString()
     }
 }
@@ -44,24 +90,28 @@ extension Data {
 extension String {
     /// Decode a base64url-encoded `String` to a base64 `String`
     /// - Returns: A base64-encoded `String`
-    public static func base64(fromBase64URLEncoded base64URLEncoded: String) -> Self {
-        return base64URLEncoded.replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
+    public static func base64(fromBase64URLEncoded base64URLEncoded: URLEncodedBase64) -> EncodedBase64 {
+        return .init(
+            base64URLEncoded.string.replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
+        )
     }
 
-    public static func base64URL(fromBase64 base64Encoded: String) -> Self {
-        return base64Encoded.replacingOccurrences(of: "+", with: "-")
-            .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: "=", with: "")
+    public static func base64URL(fromBase64 base64Encoded: EncodedBase64) -> URLEncodedBase64 {
+        return .init(
+            base64Encoded.string.replacingOccurrences(of: "+", with: "-")
+                .replacingOccurrences(of: "/", with: "_")
+                .replacingOccurrences(of: "=", with: "")
+        )
     }
 
-    func toBase64() -> String {
-        return Data(self.utf8).base64EncodedString()
+    func toBase64() -> EncodedBase64 {
+        return .init(Data(self.utf8).base64EncodedString())
     }
 }
 
-extension String {
+extension URLEncodedBase64 {
     public var base64URLDecodedData: Data? {
-        var result = self.replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
+        var result = self.string.replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
         while result.count % 4 != 0 {
             result = result.appending("=")
         }

--- a/Sources/WebAuthn/Helpers/Base64Utilities.swift
+++ b/Sources/WebAuthn/Helpers/Base64Utilities.swift
@@ -16,7 +16,7 @@ import Foundation
 import Logging
 
 /// Container for base64 encoded data
-public struct EncodedBase64: ExpressibleByStringLiteral, Codable, Hashable {
+public struct EncodedBase64: ExpressibleByStringLiteral, Codable, Hashable, Equatable {
     private let base64: String
 
     public init(_ string: String) {
@@ -63,7 +63,7 @@ public struct EncodedBase64: ExpressibleByStringLiteral, Codable, Hashable {
 }
 
 /// Container for URL encoded base64 data
-public struct URLEncodedBase64: ExpressibleByStringLiteral, Codable, Hashable {
+public struct URLEncodedBase64: ExpressibleByStringLiteral, Codable, Hashable, Equatable {
     let base64: String
 
     public init(_ string: String) {

--- a/Sources/WebAuthn/WebAuthnManager.swift
+++ b/Sources/WebAuthn/WebAuthnManager.swift
@@ -104,7 +104,7 @@ public struct WebAuthnManager {
     }
 
     public func beginAuthentication(
-        challenge: String? = nil,
+        challenge: EncodedBase64? = nil,
         timeout: TimeInterval?,
         allowCredentials: [PublicKeyCredentialDescriptor]? = nil,
         userVerification: UserVerificationRequirement = .preferred,

--- a/Sources/WebAuthn/WebAuthnManager.swift
+++ b/Sources/WebAuthn/WebAuthnManager.swift
@@ -67,7 +67,7 @@ public struct WebAuthnManager {
         // Step 3. - 16.
         let parsedData = try ParsedCredentialCreationResponse(from: credentialCreationData)
         try parsedData.verify(
-            storedChallenge: String.base64URL(fromBase64: challenge),
+            storedChallenge: challenge.urlEncoded,
             verifyUser: requireUserVerification,
             relyingPartyID: config.relyingPartyID,
             relyingPartyOrigin: config.relyingPartyOrigin
@@ -136,7 +136,7 @@ public struct WebAuthnManager {
 
         let response = credential.response
 
-        guard let clientDataData = response.clientDataJSON.base64URLDecodedData else {
+        guard let clientDataData = response.clientDataJSON.urlDecoded.decoded else {
             throw WebAuthnError.invalidClientDataJSON
         }
         let clientData = try JSONDecoder().decode(CollectedClientData.self, from: clientDataData)
@@ -147,7 +147,7 @@ public struct WebAuthnManager {
         )
         // TODO: - Verify token binding
 
-        guard let authenticatorDataBytes = response.authenticatorData.base64URLDecodedData else {
+        guard let authenticatorDataBytes = response.authenticatorData.urlDecoded.decoded else {
             throw WebAuthnError.invalidAuthenticatorData
         }
         let authenticatorData = try AuthenticatorData(bytes: authenticatorDataBytes)
@@ -175,7 +175,7 @@ public struct WebAuthnManager {
         let signatureBase = authenticatorDataBytes + clientDataHash
 
         let credentialPublicKey = try CredentialPublicKey(publicKeyBytes: credentialPublicKey)
-        guard let signatureData = response.signature.base64URLDecodedData else { throw WebAuthnError.invalidSignature }
+        guard let signatureData = response.signature.urlDecoded.decoded else { throw WebAuthnError.invalidSignature }
         try credentialPublicKey.verify(signature: signatureData, data: signatureBase)
 
         return VerifiedAuthentication(

--- a/Tests/WebAuthnTests/HelpersTests.swift
+++ b/Tests/WebAuthnTests/HelpersTests.swift
@@ -11,7 +11,14 @@ final class HelpersTests: XCTestCase {
         let base64Encoded = input.base64EncodedString()
         let base64URLEncoded = input.base64URLEncodedString()
 
-        XCTAssertEqual(expectedBase64, base64Encoded)
-        XCTAssertEqual(expectedBase64URL, base64URLEncoded)
+        XCTAssertEqual(expectedBase64, base64Encoded.string)
+        XCTAssertEqual(expectedBase64URL, base64URLEncoded.string)
+    }
+
+    func testEncodeBase64Codable() throws {
+        let base64 = EncodedBase64("AQABAAEBAAEAAQEAAAABAA==")
+        let json = try JSONEncoder().encode(base64)
+        let decodedBase64 = try JSONDecoder().decode(EncodedBase64.self, from: json)
+        XCTAssertEqual(base64, decodedBase64)
     }
 }

--- a/Tests/WebAuthnTests/HelpersTests.swift
+++ b/Tests/WebAuthnTests/HelpersTests.swift
@@ -11,8 +11,8 @@ final class HelpersTests: XCTestCase {
         let base64Encoded = input.base64EncodedString()
         let base64URLEncoded = input.base64URLEncodedString()
 
-        XCTAssertEqual(expectedBase64, base64Encoded.string)
-        XCTAssertEqual(expectedBase64URL, base64URLEncoded.string)
+        XCTAssertEqual(expectedBase64, base64Encoded.asString())
+        XCTAssertEqual(expectedBase64URL, base64URLEncoded.asString())
     }
 
     func testEncodeBase64Codable() throws {

--- a/Tests/WebAuthnTests/WebAuthnManagerTests.swift
+++ b/Tests/WebAuthnTests/WebAuthnManagerTests.swift
@@ -49,7 +49,7 @@ final class WebAuthnManagerTests: XCTestCase {
         XCTAssertEqual(options.relyingParty.id, relyingPartyID)
         XCTAssertEqual(options.relyingParty.name, relyingPartyDisplayName)
         XCTAssertEqual(options.timeout, timeout)
-        XCTAssertEqual(options.user.id, user.userID.toBase64().string)
+        XCTAssertEqual(options.user.id, user.userID.toBase64().asString())
         XCTAssertEqual(options.user.displayName, user.displayName)
         XCTAssertEqual(options.user.name, user.name)
         XCTAssertEqual(options.publicKeyCredentialParameters, [publicKeyCredentialParameter])
@@ -211,7 +211,7 @@ final class WebAuthnManagerTests: XCTestCase {
     }
 
     func testFinishRegistrationFailsIfCeremonyTypeDoesNotMatch() async throws {
-        let clientDataJSONWrongCeremonyType = String.base64URL(fromBase64: """
+        let clientDataJSONWrongCeremonyType = """
         {
             "type": "webauthn.get",
             "challenge": "cmFuZG9tU3RyaW5nRnJvbVNlcnZlcg",
@@ -219,7 +219,7 @@ final class WebAuthnManagerTests: XCTestCase {
             "crossOrigin": false,
             "other_keys_can_be_added_here": "do not compare clientDataJSON against a template. See https://goo.gl/yabPex"
         }
-        """.toBase64())
+        """.toBase64().urlEncoded
         try await assertThrowsError(
             await finishRegistration(clientDataJSON: clientDataJSONWrongCeremonyType),
             expect: CollectedClientData.CollectedClientDataVerifyError.ceremonyTypeDoesNotMatch
@@ -227,7 +227,7 @@ final class WebAuthnManagerTests: XCTestCase {
     }
 
     func testFinishRegistrationFailsIfChallengeDoesNotMatch() async throws {
-        let clientDataJSONWrongChallenge = String.base64URL(fromBase64: """
+        let clientDataJSONWrongChallenge = """
         {
             "type": "webauthn.create",
             "challenge": "cmFuZG9tU3RyaW5nRnJvbVNlcnZlcg",
@@ -235,7 +235,7 @@ final class WebAuthnManagerTests: XCTestCase {
             "crossOrigin": false,
             "other_keys_can_be_added_here": "do not compare clientDataJSON against a template. See https://goo.gl/yabPex"
         }
-        """.toBase64())
+        """.toBase64().urlEncoded
         try await assertThrowsError(
             await finishRegistration(
                 challenge: "definitelyAnotherChallenge",
@@ -246,7 +246,7 @@ final class WebAuthnManagerTests: XCTestCase {
     }
 
     func testFinishRegistrationFailsIfOriginDoesNotMatch() async throws {
-        let clientDataJSONWrongOrigin: URLEncodedBase64 = String.base64URL(fromBase64: """
+        let clientDataJSONWrongOrigin: URLEncodedBase64 = """
         {
             "type": "webauthn.create",
             "challenge": "cmFuZG9tU3RyaW5nRnJvbVNlcnZlcg",
@@ -254,7 +254,7 @@ final class WebAuthnManagerTests: XCTestCase {
             "crossOrigin": false,
             "other_keys_can_be_added_here": "do not compare clientDataJSON against a template. See https://goo.gl/yabPex"
         }
-        """.toBase64())
+        """.toBase64().urlEncoded
         // `webAuthnManager` is configured with origin = https://example.com
         try await assertThrowsError(
             await finishRegistration(
@@ -340,7 +340,7 @@ final class WebAuthnManagerTests: XCTestCase {
 
     func testFinishRegistrationFailsIfRawIDIsTooLong() async throws {
         try await assertThrowsError(
-            await finishRegistration(rawID: String.base64URL(fromBase64: [UInt8](repeating: 0, count: 1024).base64EncodedString())),
+            await finishRegistration(rawID: [UInt8](repeating: 0, count: 1024).base64EncodedString().urlEncoded),
             expect: WebAuthnError.credentialRawIDTooLong
         )
     }

--- a/Tests/WebAuthnTests/WebAuthnManagerTests.swift
+++ b/Tests/WebAuthnTests/WebAuthnManagerTests.swift
@@ -49,7 +49,7 @@ final class WebAuthnManagerTests: XCTestCase {
         XCTAssertEqual(options.relyingParty.id, relyingPartyID)
         XCTAssertEqual(options.relyingParty.name, relyingPartyDisplayName)
         XCTAssertEqual(options.timeout, timeout)
-        XCTAssertEqual(options.user.id, user.userID.toBase64())
+        XCTAssertEqual(options.user.id, user.userID.toBase64().string)
         XCTAssertEqual(options.user.displayName, user.displayName)
         XCTAssertEqual(options.user.name, user.name)
         XCTAssertEqual(options.publicKeyCredentialParameters, [publicKeyCredentialParameter])
@@ -340,18 +340,18 @@ final class WebAuthnManagerTests: XCTestCase {
 
     func testFinishRegistrationFailsIfRawIDIsTooLong() async throws {
         try await assertThrowsError(
-            await finishRegistration(rawID: [UInt8](repeating: 0, count: 1024).base64EncodedString()),
+            await finishRegistration(rawID: String.base64URL(fromBase64: [UInt8](repeating: 0, count: 1024).base64EncodedString())),
             expect: WebAuthnError.credentialRawIDTooLong
         )
     }
 
     private func finishRegistration(
         challenge: EncodedBase64 = "cmFuZG9tU3RyaW5nRnJvbVNlcnZlcg",
-        id: EncodedBase64 = "4PrJNQUJ9xdI2DeCzK9rTBRixhXHDiVdoTROQIh8j80",
+        id: String = "4PrJNQUJ9xdI2DeCzK9rTBRixhXHDiVdoTROQIh8j80",
         type: String = "public-key",
-        rawID: EncodedBase64 = "4PrJNQUJ9xdI2DeCzK9rTBRixhXHDiVdoTROQIh8j80",
-        clientDataJSON: String = "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiY21GdVpHOXRVM1J5YVc1blJuSnZiVk5sY25abGNnIiwib3JpZ2luIjoiaHR0cHM6Ly9leGFtcGxlLmNvbSIsImNyb3NzT3JpZ2luIjpmYWxzZSwib3RoZXJfa2V5c19jYW5fYmVfYWRkZWRfaGVyZSI6ImRvIG5vdCBjb21wYXJlIGNsaWVudERhdGFKU09OIGFnYWluc3QgYSB0ZW1wbGF0ZS4gU2VlIGh0dHBzOi8vZ29vLmdsL3lhYlBleCJ9",
-        attestationObject: String = "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVg5o3mm9u6vuaVeN4wRgDTidR5oL6ufLTCrE9ISVYbOGUdBAAAAAKN5pvbur7mlXjeMEYA04nUAAQAA",
+        rawID: URLEncodedBase64 = "4PrJNQUJ9xdI2DeCzK9rTBRixhXHDiVdoTROQIh8j80",
+        clientDataJSON: URLEncodedBase64 = "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiY21GdVpHOXRVM1J5YVc1blJuSnZiVk5sY25abGNnIiwib3JpZ2luIjoiaHR0cHM6Ly9leGFtcGxlLmNvbSIsImNyb3NzT3JpZ2luIjpmYWxzZSwib3RoZXJfa2V5c19jYW5fYmVfYWRkZWRfaGVyZSI6ImRvIG5vdCBjb21wYXJlIGNsaWVudERhdGFKU09OIGFnYWluc3QgYSB0ZW1wbGF0ZS4gU2VlIGh0dHBzOi8vZ29vLmdsL3lhYlBleCJ9",
+        attestationObject: URLEncodedBase64 = "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVg5o3mm9u6vuaVeN4wRgDTidR5oL6ufLTCrE9ISVYbOGUdBAAAAAKN5pvbur7mlXjeMEYA04nUAAQAA",
         requireUserVerification: Bool = false,
         confirmCredentialIDNotRegisteredYet: (String) async throws -> Bool = { _ in true }
     ) async throws -> Credential {


### PR DESCRIPTION
WIth `EncodedBase64` and `URLEncodedBase64` be type aliases of `String` it can be confusing when base64 data, url base64 encoded or even plain data is required. This PR fixes this by creating distinct types for `EncodedBase64` and `URLEncodedBase64`.

I also cleaned the APIs up slightly when moving between the various formats.