### PR TITLE
Convert PublicKeyCredentialRequestOptions.timeout to milliseconds

### DIFF
--- a/Sources/WebAuthn/Ceremonies/Authentication/PublicKeyCredentialRequestOptions.swift
+++ b/Sources/WebAuthn/Ceremonies/Authentication/PublicKeyCredentialRequestOptions.swift
@@ -18,9 +18,9 @@ import Foundation
 public struct PublicKeyCredentialRequestOptions: Codable {
     /// A challenge that the authenticator signs, along with other data, when producing an authentication assertion
     public let challenge: EncodedBase64
-    /// A `TimeInterval`, that the Relying Party is willing to wait for the call to complete. The value is treated
+    /// The number of milliseconds that the Relying Party is willing to wait for the call to complete. The value is treated
     /// as a hint, and may be overridden by the client.
-    public let timeout: TimeInterval?
+    public let timeout: UInt32?
     /// The Relying Party ID.
     public let rpId: String?
     /// Optionally used by the client to find authenticators eligible for this authentication ceremony.

--- a/Sources/WebAuthn/Ceremonies/Authentication/PublicKeyCredentialRequestOptions.swift
+++ b/Sources/WebAuthn/Ceremonies/Authentication/PublicKeyCredentialRequestOptions.swift
@@ -20,6 +20,7 @@ public struct PublicKeyCredentialRequestOptions: Codable {
     public let challenge: EncodedBase64
     /// The number of milliseconds that the Relying Party is willing to wait for the call to complete. The value is treated
     /// as a hint, and may be overridden by the client.
+    /// See https://www.w3.org/TR/webauthn-2/#dictionary-assertion-options
     public let timeout: UInt32?
     /// The Relying Party ID.
     public let rpId: String?

--- a/Sources/WebAuthn/WebAuthnManager.swift
+++ b/Sources/WebAuthn/WebAuthnManager.swift
@@ -146,9 +146,13 @@ public struct WebAuthnManager {
         userVerification: UserVerificationRequirement = .preferred
     ) throws -> PublicKeyCredentialRequestOptions {
         let challenge = challenge ?? challengeGenerator.generate().base64EncodedString()
+        var timeoutInMilliseconds: UInt32? = nil
+        if let timeout {
+            timeoutInMilliseconds = UInt32(timeout * 1000)
+        }
         return PublicKeyCredentialRequestOptions(
             challenge: challenge,
-            timeout: timeout,
+            timeout: timeoutInMilliseconds,
             rpId: config.relyingPartyID,
             allowCredentials: allowCredentials,
             userVerification: userVerification

--- a/Tests/WebAuthnTests/WebAuthnManagerAuthenticationTests.swift
+++ b/Tests/WebAuthnTests/WebAuthnManagerAuthenticationTests.swift
@@ -43,7 +43,7 @@ final class WebAuthnManagerAuthenticationTests: XCTestCase {
         )
 
         XCTAssertEqual(options.challenge, challenge.base64EncodedString())
-        XCTAssertEqual(options.timeout, 1234)
+        XCTAssertEqual(options.timeout, 1234000)    // timeout converted to milliseconds
         XCTAssertEqual(options.rpId, relyingPartyID)
         XCTAssertEqual(options.allowCredentials, allowCredentials)
         XCTAssertEqual(options.userVerification, .preferred)

--- a/Tests/WebAuthnTests/WebAuthnManagerIntegrationTests.swift
+++ b/Tests/WebAuthnTests/WebAuthnManagerIntegrationTests.swift
@@ -108,7 +108,7 @@ final class WebAuthnManagerIntegrationTests: XCTestCase {
         )
 
         XCTAssertEqual(authenticationOptions.rpId, config.relyingPartyID)
-        XCTAssertEqual(authenticationOptions.timeout, authenticationTimeout)
+        XCTAssertEqual(authenticationOptions.timeout, UInt32(authenticationTimeout * 1000)) // timeout is in milliseconds
         XCTAssertEqual(authenticationOptions.challenge, mockChallenge.base64EncodedString())
         XCTAssertEqual(authenticationOptions.userVerification, userVerification)
         XCTAssertEqual(authenticationOptions.allowCredentials, rememberedCredentials)


### PR DESCRIPTION
This updates `PublicKeyCredentialRequestOptions.timeout` to an unsigned long in milliseconds to conform to [the specification](https://www.w3.org/TR/webauthn-2/#dictionary-makecredentialoptions). 

The function `WebAuthnManager.beginAuthentication` now converts from `TimeInterval` (seconds) to milliseconds.

The unit tests are updated to verify the conversion to milliseconds.

I discovered this issue when testing [0xTim/Vapor-PasskeyDemo](https://github.com/0xTim/Vapor-PasskeyDemo) on macOS 13.3.1 (a) with Safari 16.4. Clicking the "Sign in" button caused the Safari passkey dialog to appear and instantly disappear because the timeout was set to 60 milliseconds.
