### PR TITLE
Removing explicit dependency listing.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,6 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/unrelentingtech/SwiftCBOR.git", from: "0.4.5"),
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-certificates.git", from: "0.3.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.1.0")
@@ -35,8 +34,6 @@ let package = Package(
             name: "WebAuthn",
             dependencies: [
                 "SwiftCBOR",
-                .product(name: "Crypto", package: "swift-crypto"),
-                .product(name: "_CryptoExtras", package: "swift-crypto"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "X509", package: "swift-certificates")
             ]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ easy to leverage the power of WebAuthn.
 Add the following entry in your `Package.swift` to start using `WebAuthn`:
 
 ```swift
-.package(url: "https://github.com/swift-server/webauthn-swift.git", from: "1.0.0-alpha")
+.package(url: "https://github.com/swift-server/webauthn-swift.git", from: "1.0.0-alpha.1")
 ```
 
 and `WebAuthn` dependency to your target:


### PR DESCRIPTION
## Description

This Pull Request proposes the removal of the explicitly listed `swift-crypto` dependency. The rationale behind this change is the discovery that `swift-crypto` is already included transitively through another dependency. This modification aims to simplify the dependency graph and reduce the overhead associated with managing direct dependencies.

## Key Points

- **Rationale**: The analysis revealed that `swift-crypto` is transitively included via `swift-certificates`. Eliminating the explicit dependency entry simplifies package management without sacrificing functionality. Further there was a versioning mis-match between the two declarations.

- **Impact**: Functional testing confirms that this adjustment does not alter the project's capabilities. `swift-crypto`'s functionalities remain accessible through its transitive inclusion.

- **Future Considerations**: It is recommended to monitor future updates to `swift-certificates` for any changes that might exclude `swift-crypto` from its dependencies. Should such a situation arise, reintroducing `swift-crypto` as a direct dependency may be necessary.

## Conclusion

The proposed removal of the `swift-crypto` direct dependency is intended to streamline dependency management. By leveraging the indirect inclusion of `swift-crypto`, the project maintains its functional integrity while achieving a simplified package management process.
