### PR TITLE
Use 1.0 release of Swift Certificates

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,9 +25,9 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/unrelentingtech/SwiftCBOR.git", from: "0.4.5"),
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", "2.0.0" ..< "4.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-certificates.git", from: "0.3.0"),
+        .package(url: "https://github.com/apple/swift-certificates.git", from: "1.2.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.1.0")
     ],
     targets: [


### PR DESCRIPTION
1.0 of Swift Certificates is out so we should migrate the manifest to use that with the stable API