### PR TITLE
Update dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
                 "SwiftCBOR",
                 .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "_CryptoExtras", package: "swift-crypto"),
-                .product(name: "Logging", package: "swift-log")
+                .product(name: "Logging", package: "swift-log"),
             ]
         ),
         .testTarget(name: "WebAuthnTests", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -25,9 +25,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/unrelentingtech/SwiftCBOR.git", from: "0.4.5"),
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", "2.0.0" ..< "4.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-certificates.git", from: "0.3.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.1.0")
     ],
     targets: [
@@ -37,8 +36,7 @@ let package = Package(
                 "SwiftCBOR",
                 .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "_CryptoExtras", package: "swift-crypto"),
-                .product(name: "Logging", package: "swift-log"),
-                .product(name: "X509", package: "swift-certificates")
+                .product(name: "Logging", package: "swift-log")
             ]
         ),
         .testTarget(name: "WebAuthnTests", dependencies: [


### PR DESCRIPTION
Updates Swift Crypto and removes unused Swift Certificates library. We can add Swift Certificates again when we add support for attestation verification which requires the X509 stuff.

Closes #34.