### PR TITLE
Replace SwiftCBOR with PotentCodable

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,17 +28,18 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-crypto.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-certificates.git", from: "0.3.0"),
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.1.0")
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.1.0"),
+        .package(url: "https://github.com/outfoxx/PotentCodables.git", from: "3.0.0")
     ],
     targets: [
         .target(
             name: "WebAuthn",
             dependencies: [
-                "SwiftCBOR",
                 .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "_CryptoExtras", package: "swift-crypto"),
                 .product(name: "Logging", package: "swift-log"),
-                .product(name: "X509", package: "swift-certificates")
+                .product(name: "X509", package: "swift-certificates"),
+                .product(name: "PotentCodables", package: "PotentCodables")
             ]
         ),
         .testTarget(name: "WebAuthnTests", dependencies: [

--- a/Sources/WebAuthn/Ceremonies/Registration/AttestationObject.swift
+++ b/Sources/WebAuthn/Ceremonies/Registration/AttestationObject.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import Crypto
-import SwiftCBOR
+import PotentCBOR
 
 /// Contains the cryptographic attestation that a new key pair was created by that authenticator.
 public struct AttestationObject {

--- a/Sources/WebAuthn/Ceremonies/Shared/COSE/COSEKey.swift
+++ b/Sources/WebAuthn/Ceremonies/Shared/COSE/COSEKey.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftCBOR
+import PotentCBOR
 
 enum COSEKey {
     // swiftlint:disable identifier_name

--- a/Tests/WebAuthnTests/Utils/TestModels/TestAttestationObject.swift
+++ b/Tests/WebAuthnTests/Utils/TestModels/TestAttestationObject.swift
@@ -12,10 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
 import WebAuthn
-import SwiftCBOR
-
-// protocol AttestationObjectParameter: CBOR {}
+import PotentCBOR
 
 struct TestAttestationObject {
     var fmt: CBOR?
@@ -23,7 +22,7 @@ struct TestAttestationObject {
     var authData: CBOR?
 
     var cborEncoded: [UInt8] {
-        var attestationObject: [CBOR: CBOR] = [:]
+        var attestationObject = CBOR.Map()
         if let fmt {
             attestationObject[.utf8String("fmt")] = fmt
         }
@@ -33,8 +32,8 @@ struct TestAttestationObject {
         if let authData {
             attestationObject[.utf8String("authData")] = authData
         }
-
-        return [UInt8](CBOR.map(attestationObject).encode())
+        let bytes = try! CBORSerialization.data(from: CBOR.map(attestationObject))
+        return [UInt8](bytes)
     }
 }
 
@@ -49,7 +48,7 @@ struct TestAttestationObjectBuilder {
         var temp = self
         temp.wrapped.fmt = .utf8String("none")
         temp.wrapped.attStmt = .map([:])
-        temp.wrapped.authData = .byteString(TestAuthDataBuilder().validMock().build().byteArrayRepresentation)
+        temp.wrapped.authData = .byteString(Data(TestAuthDataBuilder().validMock().build().byteArrayRepresentation))
         return temp
     }
 
@@ -111,19 +110,19 @@ struct TestAttestationObjectBuilder {
 
     func emptyAuthData() -> Self {
         var temp = self
-        temp.wrapped.authData = .byteString([])
+        temp.wrapped.authData = .byteString(Data())
         return temp
     }
 
     func zeroAuthData(byteCount: Int) -> Self {
         var temp = self
-        temp.wrapped.authData = .byteString([UInt8](repeating: 0, count: byteCount))
+        temp.wrapped.authData = .byteString(Data(repeating: 0, count: byteCount))
         return temp
     }
 
     func authData(_ builder: TestAuthDataBuilder) -> Self {
         var temp = self
-        temp.wrapped.authData = .byteString(builder.build().byteArrayRepresentation)
+        temp.wrapped.authData = .byteString(Data(builder.build().byteArrayRepresentation))
         return temp
     }
 

--- a/Tests/WebAuthnTests/Utils/TestModels/TestCredentialPublicKey.swift
+++ b/Tests/WebAuthnTests/Utils/TestModels/TestCredentialPublicKey.swift
@@ -12,8 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
 @testable import WebAuthn
-import SwiftCBOR
+import PotentCBOR
 
 struct TestCredentialPublicKey {
     var kty: CBOR?
@@ -23,7 +24,7 @@ struct TestCredentialPublicKey {
     var yCoordinate: CBOR?
 
     var byteArrayRepresentation: [UInt8] {
-        var value: [CBOR: CBOR] = [:]
+        var value = CBOR.Map()
         if let kty {
             value[COSEKey.kty.cbor] = kty
         }
@@ -39,7 +40,8 @@ struct TestCredentialPublicKey {
         if let yCoordinate {
             value[COSEKey.y.cbor] = yCoordinate
         }
-        return CBOR.map(value).encode()
+        let data = try! CBORSerialization.data(from: .map(value))
+        return [UInt8](data)
     }
 }
 
@@ -83,13 +85,13 @@ struct TestCredentialPublicKeyBuilder {
 
     func xCoordinate(_ xCoordinate: [UInt8]) -> Self {
         var temp = self
-        temp.wrapped.xCoordinate = .byteString(xCoordinate)
+        temp.wrapped.xCoordinate = .byteString(Data(xCoordinate))
         return temp
     }
 
     func yCoordiante(_ yCoordinate: [UInt8]) -> Self {
         var temp = self
-        temp.wrapped.yCoordinate = .byteString(yCoordinate)
+        temp.wrapped.yCoordinate = .byteString(Data(yCoordinate))
         return temp
     }
 }

--- a/Tests/WebAuthnTests/WebAuthnManagerAuthenticationTests.swift
+++ b/Tests/WebAuthnTests/WebAuthnManagerAuthenticationTests.swift
@@ -14,7 +14,7 @@
 
 @testable import WebAuthn
 import XCTest
-import SwiftCBOR
+import PotentCBOR
 import Crypto
 
 final class WebAuthnManagerAuthenticationTests: XCTestCase {

--- a/Tests/WebAuthnTests/WebAuthnManagerRegistrationTests.swift
+++ b/Tests/WebAuthnTests/WebAuthnManagerRegistrationTests.swift
@@ -14,7 +14,7 @@
 
 @testable import WebAuthn
 import XCTest
-import SwiftCBOR
+import PotentCBOR
 
 // swiftlint:disable:next type_body_length
 final class WebAuthnManagerRegistrationTests: XCTestCase {


### PR DESCRIPTION
[There is a bug in SwiftCBOR](https://github.com/valpackett/SwiftCBOR/issues/92) causing an application to crash when decoding large amounts of random (/invalid CBOR) bytes. I tried to find the source of this problem in SwiftCBOR, but wasn't successful with that unfortunately.