### PR TITLE
AuthenticationData decoding never decodes extension

### DIFF
--- a/Tests/WebAuthnTests/Utils/TestModels/TestAuthData.swift
+++ b/Tests/WebAuthnTests/Utils/TestModels/TestAuthData.swift
@@ -62,7 +62,7 @@ struct TestAuthDataBuilder {
     func validMock() -> Self {
         self
             .rpIDHash(fromRpID: "example.com")
-            .flags(0b01000101)
+            .flags(0b11000101)
             .counter([0b00000000, 0b00000000, 0b00000000, 0b00000000])
             .attestedCredData(
                 aaguid: [UInt8](repeating: 0, count: 16),
@@ -139,6 +139,7 @@ struct TestAuthDataBuilder {
 
     func noExtensionData() -> Self {
         var temp = self
+        temp.wrapped.flags = temp.wrapped.flags.map{ $0 & 0b01111111 }
         temp.wrapped.extensions = nil
         return temp
     }

--- a/Tests/WebAuthnTests/WebAuthnManagerRegistrationTests.swift
+++ b/Tests/WebAuthnTests/WebAuthnManagerRegistrationTests.swift
@@ -200,7 +200,7 @@ final class WebAuthnManagerRegistrationTests: XCTestCase {
             await finishRegistration(
                 attestationObject: TestAttestationObjectBuilder()
                     .validMock()
-                    .authData(TestAuthDataBuilder().validMock().flags(0b11000001).noExtensionData())
+                    .authData(TestAuthDataBuilder().validMock().noExtensionData().flags(0b11000001))
                     .build()
                     .cborEncoded
             ),
@@ -248,7 +248,7 @@ final class WebAuthnManagerRegistrationTests: XCTestCase {
             await finishRegistration(
                 attestationObject: TestAttestationObjectBuilder()
                     .validMock()
-                    .authData(TestAuthDataBuilder().validMock().flags(0b01000000))
+                    .authData(TestAuthDataBuilder().validMock().flags(0b11000000))
                     .build()
                     .cborEncoded
             ),
@@ -261,7 +261,7 @@ final class WebAuthnManagerRegistrationTests: XCTestCase {
             await finishRegistration(
                 attestationObject: TestAttestationObjectBuilder()
                     .validMock()
-                    .authData(TestAuthDataBuilder().validMock().flags(0b01000001))
+                    .authData(TestAuthDataBuilder().validMock().flags(0b11000001))
                     .build()
                     .cborEncoded,
                 requireUserVerification: true


### PR DESCRIPTION
While auditing the code, I noticed that `AuthenticationData`'s `parseAttestedData()` greedily assumes that the rest of the range is the public key. However, if the `extensionDataIncluded` flag is set, extension data would not exist (because it was gobbled into the public key), and thus decoding would fail rendering a potentially valid `AuthenticationData` unusable.

Here, we instead try decoding a CBOR item, and if successful, use only its bytes for the public key, leaving the rest for the extension.