### PR TITLE
Some minor refactoring suggestions in public model layer.

### DIFF
--- a/Sources/WebAuthn/Ceremonies/Authentication/AuthenticatorAssertionResponse.swift
+++ b/Sources/WebAuthn/Ceremonies/Authentication/AuthenticatorAssertionResponse.swift
@@ -83,7 +83,7 @@ struct ParsedAuthenticatorAssertionResponse {
 
         rawAuthenticatorData = Data(authenticatorAssertionResponse.authenticatorData)
         authenticatorData = try AuthenticatorData(bytes: rawAuthenticatorData)
-        signature = authenticatorAssertionResponse.signature.base64URLEncodedString()
+        signature = authenticatorAssertionResponse.signature.base64URLEncoded()
         userHandle = authenticatorAssertionResponse.userHandle
     }
 
@@ -127,7 +127,7 @@ struct ParsedAuthenticatorAssertionResponse {
         let signatureBase = rawAuthenticatorData + clientDataHash
 
         let credentialPublicKey = try CredentialPublicKey(publicKeyBytes: credentialPublicKey)
-        guard let signatureData = signature.urlDecoded.decoded else { throw WebAuthnError.invalidSignature }
-        try credentialPublicKey.verify(signature: signatureData, data: signatureBase)
+        guard let decodedBytes = signature.urlDecoded.decodedBytes else { throw WebAuthnError.invalidSignature }
+        try credentialPublicKey.verify(signature: Data(decodedBytes), data: signatureBase)
     }
 }

--- a/Sources/WebAuthn/Ceremonies/Authentication/AuthenticatorAssertionResponse.swift
+++ b/Sources/WebAuthn/Ceremonies/Authentication/AuthenticatorAssertionResponse.swift
@@ -83,7 +83,7 @@ struct ParsedAuthenticatorAssertionResponse {
 
         rawAuthenticatorData = Data(authenticatorAssertionResponse.authenticatorData)
         authenticatorData = try AuthenticatorData(bytes: rawAuthenticatorData)
-        signature = authenticatorAssertionResponse.signature.base64URLEncoded()
+        signature = URLEncodedBase64(bytes: authenticatorAssertionResponse.signature)
         userHandle = authenticatorAssertionResponse.userHandle
     }
 
@@ -127,7 +127,7 @@ struct ParsedAuthenticatorAssertionResponse {
         let signatureBase = rawAuthenticatorData + clientDataHash
 
         let credentialPublicKey = try CredentialPublicKey(publicKeyBytes: credentialPublicKey)
-        guard let decodedBytes = signature.urlDecoded.decodedBytes else { throw WebAuthnError.invalidSignature }
+        guard let decodedBytes = EncodedBase64(base64URL: signature).decodedBytes else { throw WebAuthnError.invalidSignature }
         try credentialPublicKey.verify(signature: Data(decodedBytes), data: signatureBase)
     }
 }

--- a/Sources/WebAuthn/Ceremonies/Authentication/PublicKeyCredentialRequestOptions.swift
+++ b/Sources/WebAuthn/Ceremonies/Authentication/PublicKeyCredentialRequestOptions.swift
@@ -42,7 +42,7 @@ public struct PublicKeyCredentialRequestOptions: Encodable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
-        try container.encode(challenge.base64URLEncodedString(), forKey: .challenge)
+        try container.encode(challenge.base64URLEncoded(), forKey: .challenge)
         try container.encodeIfPresent(timeout, forKey: .timeout)
         try container.encodeIfPresent(rpId, forKey: .rpId)
         try container.encodeIfPresent(allowCredentials, forKey: .allowCredentials)
@@ -101,7 +101,7 @@ public struct PublicKeyCredentialDescriptor: Equatable, Encodable {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
         try container.encode(type, forKey: .type)
-        try container.encode(id.base64URLEncodedString(), forKey: .id)
+        try container.encode(id.base64URLEncoded(), forKey: .id)
         try container.encodeIfPresent(transports, forKey: .transports)
     }
 

--- a/Sources/WebAuthn/Ceremonies/Authentication/PublicKeyCredentialRequestOptions.swift
+++ b/Sources/WebAuthn/Ceremonies/Authentication/PublicKeyCredentialRequestOptions.swift
@@ -41,8 +41,8 @@ public struct PublicKeyCredentialRequestOptions: Encodable {
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-
-        try container.encode(challenge.base64URLEncoded(), forKey: .challenge)
+        
+        try container.encode(URLEncodedBase64(bytes: challenge), forKey: .challenge)
         try container.encodeIfPresent(timeout, forKey: .timeout)
         try container.encodeIfPresent(rpId, forKey: .rpId)
         try container.encodeIfPresent(allowCredentials, forKey: .allowCredentials)
@@ -99,9 +99,9 @@ public struct PublicKeyCredentialDescriptor: Equatable, Encodable {
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-
+        
         try container.encode(type, forKey: .type)
-        try container.encode(id.base64URLEncoded(), forKey: .id)
+        try container.encode(URLEncodedBase64(bytes: id), forKey: .id)
         try container.encodeIfPresent(transports, forKey: .transports)
     }
 

--- a/Sources/WebAuthn/Ceremonies/Registration/PublicKeyCredentialCreationOptions.swift
+++ b/Sources/WebAuthn/Ceremonies/Registration/PublicKeyCredentialCreationOptions.swift
@@ -44,8 +44,8 @@ public struct PublicKeyCredentialCreationOptions: Encodable {
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-
-        try container.encode(challenge.base64URLEncoded(), forKey: .challenge)
+        
+        try container.encode(URLEncodedBase64(bytes: challenge), forKey: .challenge)
         try container.encode(user, forKey: .user)
         try container.encode(relyingParty, forKey: .relyingParty)
         try container.encode(publicKeyCredentialParameters, forKey: .publicKeyCredentialParameters)
@@ -139,8 +139,8 @@ public struct PublicKeyCredentialUserEntity: Encodable {
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-
-        try container.encode(id.base64URLEncoded(), forKey: .id)
+        
+        try container.encode(URLEncodedBase64(bytes: id), forKey: .id)
         try container.encode(name, forKey: .name)
         try container.encode(displayName, forKey: .displayName)
     }

--- a/Sources/WebAuthn/Ceremonies/Registration/PublicKeyCredentialCreationOptions.swift
+++ b/Sources/WebAuthn/Ceremonies/Registration/PublicKeyCredentialCreationOptions.swift
@@ -45,7 +45,7 @@ public struct PublicKeyCredentialCreationOptions: Encodable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
-        try container.encode(challenge.base64URLEncodedString(), forKey: .challenge)
+        try container.encode(challenge.base64URLEncoded(), forKey: .challenge)
         try container.encode(user, forKey: .user)
         try container.encode(relyingParty, forKey: .relyingParty)
         try container.encode(publicKeyCredentialParameters, forKey: .publicKeyCredentialParameters)
@@ -140,7 +140,7 @@ public struct PublicKeyCredentialUserEntity: Encodable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
-        try container.encode(id.base64URLEncodedString(), forKey: .id)
+        try container.encode(id.base64URLEncoded(), forKey: .id)
         try container.encode(name, forKey: .name)
         try container.encode(displayName, forKey: .displayName)
     }

--- a/Sources/WebAuthn/Ceremonies/Shared/CollectedClientData.swift
+++ b/Sources/WebAuthn/Ceremonies/Shared/CollectedClientData.swift
@@ -37,7 +37,8 @@ public struct CollectedClientData: Codable, Hashable {
 
     func verify(storedChallenge: [UInt8], ceremonyType: CeremonyType, relyingPartyOrigin: String) throws {
         guard type == ceremonyType else { throw CollectedClientDataVerifyError.ceremonyTypeDoesNotMatch }
-        guard challenge == storedChallenge.base64URLEncoded() else {
+        
+        guard challenge == URLEncodedBase64(bytes: storedChallenge) else {
             throw CollectedClientDataVerifyError.challengeDoesNotMatch
         }
         guard origin == relyingPartyOrigin else { throw CollectedClientDataVerifyError.originDoesNotMatch }

--- a/Sources/WebAuthn/Ceremonies/Shared/CollectedClientData.swift
+++ b/Sources/WebAuthn/Ceremonies/Shared/CollectedClientData.swift
@@ -37,7 +37,7 @@ public struct CollectedClientData: Codable, Hashable {
 
     func verify(storedChallenge: [UInt8], ceremonyType: CeremonyType, relyingPartyOrigin: String) throws {
         guard type == ceremonyType else { throw CollectedClientDataVerifyError.ceremonyTypeDoesNotMatch }
-        guard challenge == storedChallenge.base64URLEncodedString() else {
+        guard challenge == storedChallenge.base64URLEncoded() else {
             throw CollectedClientDataVerifyError.challengeDoesNotMatch
         }
         guard origin == relyingPartyOrigin else { throw CollectedClientDataVerifyError.originDoesNotMatch }

--- a/Sources/WebAuthn/Helpers/Base64Utilities.swift
+++ b/Sources/WebAuthn/Helpers/Base64Utilities.swift
@@ -16,102 +16,103 @@ import Foundation
 import Logging
 
 /// Container for base64 encoded data
-public struct EncodedBase64: ExpressibleByStringLiteral, Codable, Hashable, Equatable {
-    private let base64: String
-
-    public init(_ string: String) {
-        self.base64 = string
+public struct EncodedBase64: Codable, Hashable, Equatable, ExpressibleByStringLiteral {
+    
+    public let value: String
+    
+    public init(value: String) {
+        self.value = value
     }
 
     public init(stringLiteral value: StringLiteralType) {
-        self.init(value)
+        self.init(value: value)
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        self.base64 = try container.decode(String.self)
+        let value = try container.decode(String.self)
+        self.init(value: value)
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
-        try container.encode(self.base64)
+        try container.encode(self.value)
+    }
+    
+    var urlEncoded: URLEncodedBase64 {
+        URLEncodedBase64(base64: self)
     }
 
-    /// Return as Base64URL
-    public var urlEncoded: URLEncodedBase64 {
-        return .init(
-            self.base64.replacingOccurrences(of: "+", with: "-")
-                .replacingOccurrences(of: "/", with: "_")
-                .replacingOccurrences(of: "=", with: "")
-        )
-    }
-
-    /// Decodes Base64 string and transforms result into `Data`
-    public var decoded: Data? {
-        return Data(base64Encoded: self.base64)
-    }
-
-    /// Returns Base64 data as a String
-    public func asString() -> String {
-        return self.base64
+    /// Decodes Base64 string and transforms result into `[UInt8]`
+    public var decodedBytes: [UInt8]? {
+        guard let data = Data(base64Encoded: self.value) else {
+            return nil
+        }
+        return [UInt8](data)
     }
 }
 
 /// Container for URL encoded base64 data
-public struct URLEncodedBase64: ExpressibleByStringLiteral, Codable, Hashable, Equatable {
-    let base64URL: String
+public struct URLEncodedBase64: Codable, Hashable, Equatable, ExpressibleByStringLiteral {
+    
+    public let value: String
+    
+    public init(value: String) {
+        self.value = value
+    }
+    
+    public init(stringLiteral value: StringLiteralType) {
+        self.init(value: value)
+    }
 
     /// Decodes Base64URL string and transforms result into `[UInt8]`
     public var decodedBytes: [UInt8]? {
-        guard let base64DecodedData = urlDecoded.decoded else { return nil }
-        return [UInt8](base64DecodedData)
+        urlDecoded.decodedBytes
     }
 
-    public init(_ string: String) {
-        self.base64URL = string
-    }
-
-    public init(stringLiteral value: StringLiteralType) {
-        self.init(value)
+    public init(base64: EncodedBase64) {
+        let value = base64.value
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        self.init(value: value)
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        self.base64URL = try container.decode(String.self)
+        let value = try container.decode(String.self)
+        self.init(value: value)
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
-        try container.encode(self.base64URL)
+        try container.encode(self.value)
     }
 
     /// Decodes Base64URL into Base64
     public var urlDecoded: EncodedBase64 {
-        var result = self.base64URL.replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
-        while result.count % 4 != 0 {
-            result = result.appending("=")
+        var value = self.value
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        while value.count % 4 != 0 {
+            value = value.appending("=")
         }
-        return .init(result)
-    }
-
-    /// Return Base64URL as a String
-    public func asString() -> String {
-        return self.base64URL
+        return .init(value: value)
     }
 }
 
 extension Array where Element == UInt8 {
     /// Encodes an array of bytes into a base64url-encoded string
     /// - Returns: A base64url-encoded string
-    public func base64URLEncodedString() -> URLEncodedBase64 {
+    public func base64URLEncoded() -> URLEncodedBase64 {
         let base64String = Data(bytes: self, count: self.count).base64EncodedString()
-        return EncodedBase64(base64String).urlEncoded
+        return EncodedBase64(value: base64String).urlEncoded
     }
 
     /// Encodes an array of bytes into a base64 string
     /// - Returns: A base64-encoded string
-    public func base64EncodedString() -> EncodedBase64 {
-        return .init(Data(bytes: self, count: self.count).base64EncodedString())
+    public func base64Encoded() -> EncodedBase64 {
+        return .init(value: Data(bytes: self, count: self.count).base64EncodedString())
     }
 }
 
@@ -119,12 +120,12 @@ extension Data {
     /// Encodes data into a base64url-encoded string
     /// - Returns: A base64url-encoded string
     public func base64URLEncodedString() -> URLEncodedBase64 {
-        return [UInt8](self).base64URLEncodedString()
+        return [UInt8](self).base64URLEncoded()
     }
 }
 
 extension String {
     func toBase64() -> EncodedBase64 {
-        return .init(Data(self.utf8).base64EncodedString())
+        return .init(value: Data(self.utf8).base64EncodedString())
     }
 }

--- a/Sources/WebAuthn/WebAuthnManager.swift
+++ b/Sources/WebAuthn/WebAuthnManager.swift
@@ -115,11 +115,11 @@ public struct WebAuthnManager {
         guard try await confirmCredentialIDNotRegisteredYet(parsedData.id.value) else {
             throw WebAuthnError.credentialIDAlreadyExists
         }
-
+        
         // Step 25.
         return Credential(
             type: parsedData.type,
-            id: parsedData.id.urlDecoded.value,
+            id: EncodedBase64(base64URL: parsedData.id).value,
             publicKey: attestedCredentialData.publicKey,
             signCount: parsedData.response.attestationObject.authenticatorData.counter,
             backupEligible: parsedData.response.attestationObject.authenticatorData.flags.isBackupEligible,

--- a/Sources/WebAuthn/WebAuthnManager.swift
+++ b/Sources/WebAuthn/WebAuthnManager.swift
@@ -112,14 +112,14 @@ public struct WebAuthnManager {
         // TODO: Step 18. -> Verify client extensions
 
         // Step 24.
-        guard try await confirmCredentialIDNotRegisteredYet(parsedData.id.asString()) else {
+        guard try await confirmCredentialIDNotRegisteredYet(parsedData.id.value) else {
             throw WebAuthnError.credentialIDAlreadyExists
         }
 
         // Step 25.
         return Credential(
             type: parsedData.type,
-            id: parsedData.id.urlDecoded.asString(),
+            id: parsedData.id.urlDecoded.value,
             publicKey: attestedCredentialData.publicKey,
             signCount: parsedData.response.attestationObject.authenticatorData.counter,
             backupEligible: parsedData.response.attestationObject.authenticatorData.flags.isBackupEligible,

--- a/Tests/WebAuthnTests/HelpersTests.swift
+++ b/Tests/WebAuthnTests/HelpersTests.swift
@@ -22,11 +22,11 @@ final class HelpersTests: XCTestCase {
         let expectedBase64 = "AQABAAEBAAEAAQEAAAABAA=="
         let expectedBase64URL = "AQABAAEBAAEAAQEAAAABAA"
 
-        let base64Encoded = input.base64EncodedString()
-        let base64URLEncoded = input.base64URLEncodedString()
+        let base64Encoded = input.base64Encoded()
+        let base64URLEncoded = input.base64URLEncoded()
 
-        XCTAssertEqual(expectedBase64, base64Encoded.asString())
-        XCTAssertEqual(expectedBase64URL, base64URLEncoded.asString())
+        XCTAssertEqual(expectedBase64, base64Encoded.value)
+        XCTAssertEqual(expectedBase64URL, base64URLEncoded.value)
     }
 
     func testEncodeBase64Codable() throws {

--- a/Tests/WebAuthnTests/HelpersTests.swift
+++ b/Tests/WebAuthnTests/HelpersTests.swift
@@ -21,16 +21,15 @@ final class HelpersTests: XCTestCase {
         let input: [UInt8] = [1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 0, 0, 1, 0]
         let expectedBase64 = "AQABAAEBAAEAAQEAAAABAA=="
         let expectedBase64URL = "AQABAAEBAAEAAQEAAAABAA"
-
-        let base64Encoded = input.base64Encoded()
-        let base64URLEncoded = input.base64URLEncoded()
-
+        let base64Encoded = EncodedBase64(bytes: input)
+        let base64URLEncoded = URLEncodedBase64(bytes: input)
+        
         XCTAssertEqual(expectedBase64, base64Encoded.value)
         XCTAssertEqual(expectedBase64URL, base64URLEncoded.value)
     }
 
     func testEncodeBase64Codable() throws {
-        let base64 = EncodedBase64("AQABAAEBAAEAAQEAAAABAA==")
+        let base64 = EncodedBase64(base64Encoded: "AQABAAEBAAEAAQEAAAABAA==")
         let json = try JSONEncoder().encode(base64)
         let decodedBase64 = try JSONDecoder().decode(EncodedBase64.self, from: json)
         XCTAssertEqual(base64, decodedBase64)

--- a/Tests/WebAuthnTests/Utils/TestModels/TestAttestationObject.swift
+++ b/Tests/WebAuthnTests/Utils/TestModels/TestAttestationObject.swift
@@ -58,7 +58,7 @@ struct TestAttestationObjectBuilder {
     }
 
     func buildBase64URLEncoded() -> URLEncodedBase64 {
-        build().cborEncoded.base64URLEncodedString()
+        build().cborEncoded.base64URLEncoded()
     }
 
     // MARK: fmt

--- a/Tests/WebAuthnTests/Utils/TestModels/TestAttestationObject.swift
+++ b/Tests/WebAuthnTests/Utils/TestModels/TestAttestationObject.swift
@@ -58,7 +58,7 @@ struct TestAttestationObjectBuilder {
     }
 
     func buildBase64URLEncoded() -> URLEncodedBase64 {
-        build().cborEncoded.base64URLEncoded()
+        URLEncodedBase64(bytes: build().cborEncoded)
     }
 
     // MARK: fmt

--- a/Tests/WebAuthnTests/Utils/TestModels/TestAuthData.swift
+++ b/Tests/WebAuthnTests/Utils/TestModels/TestAuthData.swift
@@ -56,7 +56,7 @@ struct TestAuthDataBuilder {
     }
 
     func buildAsBase64URLEncoded() -> URLEncodedBase64 {
-        build().byteArrayRepresentation.base64URLEncodedString()
+        build().byteArrayRepresentation.base64URLEncoded()
     }
 
     func validMock() -> Self {

--- a/Tests/WebAuthnTests/Utils/TestModels/TestAuthData.swift
+++ b/Tests/WebAuthnTests/Utils/TestModels/TestAuthData.swift
@@ -56,7 +56,7 @@ struct TestAuthDataBuilder {
     }
 
     func buildAsBase64URLEncoded() -> URLEncodedBase64 {
-        build().byteArrayRepresentation.base64URLEncoded()
+        URLEncodedBase64(bytes: build().byteArrayRepresentation)
     }
 
     func validMock() -> Self {

--- a/Tests/WebAuthnTests/Utils/TestModels/TestClientDataJSON.swift
+++ b/Tests/WebAuthnTests/Utils/TestModels/TestClientDataJSON.swift
@@ -17,7 +17,7 @@ import WebAuthn
 
 struct TestClientDataJSON: Encodable {
     var type = "webauthn.create"
-    var challenge: URLEncodedBase64 = TestConstants.mockChallenge.base64URLEncodedString()
+    var challenge: URLEncodedBase64 = TestConstants.mockChallenge.base64URLEncoded()
     var origin = "https://example.com"
     var crossOrigin = false
     var randomOtherKey = "123"

--- a/Tests/WebAuthnTests/Utils/TestModels/TestClientDataJSON.swift
+++ b/Tests/WebAuthnTests/Utils/TestModels/TestClientDataJSON.swift
@@ -17,13 +17,13 @@ import WebAuthn
 
 struct TestClientDataJSON: Encodable {
     var type = "webauthn.create"
-    var challenge: URLEncodedBase64 = TestConstants.mockChallenge.base64URLEncoded()
+    var challenge: URLEncodedBase64 = URLEncodedBase64(bytes: TestConstants.mockChallenge)
     var origin = "https://example.com"
     var crossOrigin = false
     var randomOtherKey = "123"
 
     var base64URLEncoded: URLEncodedBase64 {
-        jsonData.base64URLEncodedString()
+        URLEncodedBase64(data: jsonData)
     }
 
     /// Returns this `TestClientDataJSON` as encoded json. On **Linux** this is NOT idempotent. Subsequent calls

--- a/Tests/WebAuthnTests/Utils/TestModels/TestECCKeyPair.swift
+++ b/Tests/WebAuthnTests/Utils/TestModels/TestECCKeyPair.swift
@@ -48,10 +48,10 @@ struct TestECCKeyPair {
         // Create a signature. This part is usually performed by the authenticator
         let clientData: Data = TestClientDataJSON(type: "webauthn.get").jsonData
         let clientDataHash = SHA256.hash(data: clientData)
-        let rawAuthenticatorData = authenticatorData.urlDecoded.decoded!
+        let rawAuthenticatorData = authenticatorData.urlDecoded.decodedBytes!
         let signatureBase = rawAuthenticatorData + clientDataHash
         // swiftlint:disable:next force_try
-        let signature = try! TestECCKeyPair.signature(data: signatureBase).derRepresentation
+        let signature = try! TestECCKeyPair.signature(data: Data(signatureBase)).derRepresentation
 
         return [UInt8](signature)
     }

--- a/Tests/WebAuthnTests/Utils/TestModels/TestECCKeyPair.swift
+++ b/Tests/WebAuthnTests/Utils/TestModels/TestECCKeyPair.swift
@@ -48,7 +48,7 @@ struct TestECCKeyPair {
         // Create a signature. This part is usually performed by the authenticator
         let clientData: Data = TestClientDataJSON(type: "webauthn.get").jsonData
         let clientDataHash = SHA256.hash(data: clientData)
-        let rawAuthenticatorData = authenticatorData.urlDecoded.decodedBytes!
+        let rawAuthenticatorData = EncodedBase64(base64URL: authenticatorData).decodedBytes!
         let signatureBase = rawAuthenticatorData + clientDataHash
         // swiftlint:disable:next force_try
         let signature = try! TestECCKeyPair.signature(data: Data(signatureBase)).derRepresentation

--- a/Tests/WebAuthnTests/WebAuthnManagerAuthenticationTests.swift
+++ b/Tests/WebAuthnTests/WebAuthnManagerAuthenticationTests.swift
@@ -152,8 +152,8 @@ final class WebAuthnManagerAuthenticationTests: XCTestCase {
             signature: [UInt8](signature),
             credentialCurrentSignCount: oldSignCount
         )
-
-        XCTAssertEqual(verifiedAuthentication.credentialID, credentialID.base64URLEncoded())
+        
+        XCTAssertEqual(verifiedAuthentication.credentialID, URLEncodedBase64(bytes: credentialID))
         XCTAssertEqual(verifiedAuthentication.newSignCount, oldSignCount + 1)
     }
 
@@ -174,7 +174,7 @@ final class WebAuthnManagerAuthenticationTests: XCTestCase {
     ) throws -> VerifiedAuthentication {
         try webAuthnManager.finishAuthentication(
             credential: AuthenticationCredential(
-                id: credentialID.base64URLEncoded(),
+                id: URLEncodedBase64(bytes: credentialID),
                 rawID: credentialID,
                 response: AuthenticatorAssertionResponse(
                     clientDataJSON: clientDataJSON,

--- a/Tests/WebAuthnTests/WebAuthnManagerAuthenticationTests.swift
+++ b/Tests/WebAuthnTests/WebAuthnManagerAuthenticationTests.swift
@@ -153,7 +153,7 @@ final class WebAuthnManagerAuthenticationTests: XCTestCase {
             credentialCurrentSignCount: oldSignCount
         )
 
-        XCTAssertEqual(verifiedAuthentication.credentialID, credentialID.base64URLEncodedString())
+        XCTAssertEqual(verifiedAuthentication.credentialID, credentialID.base64URLEncoded())
         XCTAssertEqual(verifiedAuthentication.newSignCount, oldSignCount + 1)
     }
 
@@ -174,7 +174,7 @@ final class WebAuthnManagerAuthenticationTests: XCTestCase {
     ) throws -> VerifiedAuthentication {
         try webAuthnManager.finishAuthentication(
             credential: AuthenticationCredential(
-                id: credentialID.base64URLEncodedString(),
+                id: credentialID.base64URLEncoded(),
                 rawID: credentialID,
                 response: AuthenticatorAssertionResponse(
                     clientDataJSON: clientDataJSON,

--- a/Tests/WebAuthnTests/WebAuthnManagerRegistrationTests.swift
+++ b/Tests/WebAuthnTests/WebAuthnManagerRegistrationTests.swift
@@ -66,7 +66,7 @@ final class WebAuthnManagerRegistrationTests: XCTestCase {
 
     func testFinishRegistrationFailsIfChallengeDoesNotMatch() async throws {
         var clientDataJSON = TestClientDataJSON()
-        clientDataJSON.challenge = [0, 2, 4].base64URLEncodedString()
+        clientDataJSON.challenge = [0, 2, 4].base64URLEncoded()
         try await assertThrowsError(
             await finishRegistration(
                 challenge: [UInt8]("definitely another challenge".utf8),
@@ -311,7 +311,7 @@ final class WebAuthnManagerRegistrationTests: XCTestCase {
         )
         XCTAssertNotNil(credential)
 
-        XCTAssertEqual(credential.id, credentialID.base64EncodedString().asString())
+        XCTAssertEqual(credential.id, credentialID.base64URLEncoded().value)
         XCTAssertEqual(credential.publicKey, credentialPublicKey)
     }
 
@@ -340,7 +340,7 @@ final class WebAuthnManagerRegistrationTests: XCTestCase {
         try await webAuthnManager.finishRegistration(
             challenge: challenge,
             credentialCreationData: RegistrationCredential(
-                id: rawID.base64URLEncodedString(),
+                id: rawID.base64URLEncoded(),
                 type: type,
                 rawID: rawID,
                 attestationResponse: AuthenticatorAttestationResponse(

--- a/Tests/WebAuthnTests/WebAuthnManagerRegistrationTests.swift
+++ b/Tests/WebAuthnTests/WebAuthnManagerRegistrationTests.swift
@@ -66,7 +66,7 @@ final class WebAuthnManagerRegistrationTests: XCTestCase {
 
     func testFinishRegistrationFailsIfChallengeDoesNotMatch() async throws {
         var clientDataJSON = TestClientDataJSON()
-        clientDataJSON.challenge = [0, 2, 4].base64URLEncoded()
+        clientDataJSON.challenge = URLEncodedBase64(bytes: [0, 2, 4])
         try await assertThrowsError(
             await finishRegistration(
                 challenge: [UInt8]("definitely another challenge".utf8),
@@ -310,8 +310,8 @@ final class WebAuthnManagerRegistrationTests: XCTestCase {
             attestationObject: attestationObject
         )
         XCTAssertNotNil(credential)
-
-        XCTAssertEqual(credential.id, credentialID.base64URLEncoded().value)
+        
+        XCTAssertEqual(credential.id, URLEncodedBase64(bytes: credentialID).value)
         XCTAssertEqual(credential.publicKey, credentialPublicKey)
     }
 
@@ -340,7 +340,7 @@ final class WebAuthnManagerRegistrationTests: XCTestCase {
         try await webAuthnManager.finishRegistration(
             challenge: challenge,
             credentialCreationData: RegistrationCredential(
-                id: rawID.base64URLEncoded(),
+                id: URLEncodedBase64(bytes: rawID),
                 type: type,
                 rawID: rawID,
                 attestationResponse: AuthenticatorAttestationResponse(


### PR DESCRIPTION
This PR is just a few small refactoring suggestions that I noticed when isolating model files for my own needs (discussed [here](https://github.com/swift-server/webauthn-swift/issues/40)).

### Change 1 of 6

Added some new inits such as this (to `URLEncodedBase64`).

```swift
init(base64: EncodedBase64) {
    let value = base64.value
        .replacingOccurrences(of: "+", with: "-")
        .replacingOccurrences(of: "/", with: "_")
        .replacingOccurrences(of: "=", with: "")
    self.init(value: value)
}
```

### Change 2 of 6

Change property `decoded` to `decodedBytes` for consistency across both `EncodedBase64` and `URLEncodedBase64`.

> Side question: would an empty array be more appropriate than a nil array ?

```swift
var decodedBytes: [UInt8]?
```

### Change 3 of 6

Change name of `func base64URLEncodedString() -> URLEncodedBase64` as it doesn't return a string per se.

### Change 4 of 6

Replaced

```swift
extension Data {
    /// Encodes data into a base64url-encoded string
    /// - Returns: A base64url-encoded string
    public func base64URLEncodedString() -> URLEncodedBase64 {
        return [UInt8](self).base64URLEncoded()
    }
}
```

with

```swift
public init(data: Data) {
    let base64EncodedString = data.base64EncodedString()
    let base64Encoded = EncodedBase64(value: base64EncodedString)
    self.init(base64: base64Encoded)
}
```

### Change 5 of 6

Replaced

```swift
extension Array where Element == UInt8 {
    /// Encodes an array of bytes into a base64url-encoded string
    /// - Returns: A base64url-encoded string
    public func base64URLEncoded() -> URLEncodedBase64 {
        let data = Data(bytes: self, count: self.count)
        let base64EncodedString = data.base64EncodedString()
        let base64Encoded = EncodedBase64(value: base64EncodedString)
        return URLEncodedBase64(base64: base64Encoded)
    }
}
```

with

```swift
public init(bytes: [UInt8]) {
    let data = Data(bytes: bytes, count: bytes.count)
    let base64EncodedString = data.base64EncodedString()
    let base64Encoded = EncodedBase64(value: base64EncodedString)
    self.init(base64: base64Encoded)
}
```

### Change 6 of 6

Removed

```swift
extension String {
    func toBase64() -> EncodedBase64 {
        return .init(value: Data(self.utf8).base64EncodedString())
    }
}
```