### PR TITLE
AuthenticatorData  credentialID length check as per spec

### DIFF
--- a/Sources/WebAuthn/WebAuthnError.swift
+++ b/Sources/WebAuthn/WebAuthnError.swift
@@ -49,6 +49,7 @@ public enum WebAuthnError: Error, Equatable {
     case attestedCredentialFlagNotSet
     case extensionDataMissing
     case leftOverBytesInAuthenticatorData
+    case credentialIDTooLong
     case credentialIDTooShort
 
     // MARK: CredentialPublicKey


### PR DESCRIPTION
Added a check per spec for the credentialID length when deserialized AuthenticatorData.

Fixes #39