### PR TITLE
Relying Party Spelling

### DIFF
--- a/Sources/WebAuthn/Ceremonies/Authentication/AuthenticatorAssertionResponse.swift
+++ b/Sources/WebAuthn/Ceremonies/Authentication/AuthenticatorAssertionResponse.swift
@@ -102,11 +102,11 @@ struct ParsedAuthenticatorAssertionResponse {
             relyingPartyOrigin: relyingPartyOrigin
         )
 
-        guard let expectedRpIDData = relyingPartyID.data(using: .utf8) else {
+        guard let expectedRelyingPartyIDData = relyingPartyID.data(using: .utf8) else {
             throw WebAuthnError.invalidRelyingPartyID
         }
-        let expectedRpIDHash = SHA256.hash(data: expectedRpIDData)
-        guard expectedRpIDHash == authenticatorData.relyingPartyIDHash else {
+        let expectedRelyingPartyIDHash = SHA256.hash(data: expectedRelyingPartyIDData)
+        guard expectedRelyingPartyIDHash == authenticatorData.relyingPartyIDHash else {
             throw WebAuthnError.relyingPartyIDHashDoesNotMatch
         }
 

--- a/Sources/WebAuthn/Ceremonies/Authentication/PublicKeyCredentialRequestOptions.swift
+++ b/Sources/WebAuthn/Ceremonies/Authentication/PublicKeyCredentialRequestOptions.swift
@@ -32,8 +32,11 @@ public struct PublicKeyCredentialRequestOptions: Encodable {
     /// See https://www.w3.org/TR/webauthn-2/#dictionary-assertion-options
     public let timeout: Duration?
 
-    /// The Relying Party ID.
-    public let rpId: String?
+    /// The ID of the Relying Party making the request.
+    ///
+    /// This is configured on ``WebAuthnManager`` before its ``WebAuthnManager/beginAuthentication(timeout:allowCredentials:userVerification:)`` method is called.
+    /// - Note: When encoded, this field appears as `rpId` to match the expectations of `navigator.credentials.get()`.
+    public let relyingPartyID: String?
 
     /// Optionally used by the client to find authenticators eligible for this authentication ceremony.
     public let allowCredentials: [PublicKeyCredentialDescriptor]?
@@ -48,7 +51,7 @@ public struct PublicKeyCredentialRequestOptions: Encodable {
 
         try container.encode(challenge.base64URLEncodedString(), forKey: .challenge)
         try container.encodeIfPresent(timeout?.milliseconds, forKey: .timeout)
-        try container.encodeIfPresent(rpId, forKey: .rpId)
+        try container.encodeIfPresent(relyingPartyID, forKey: .rpID)
         try container.encodeIfPresent(allowCredentials, forKey: .allowCredentials)
         try container.encodeIfPresent(userVerification, forKey: .userVerification)
     }
@@ -56,7 +59,7 @@ public struct PublicKeyCredentialRequestOptions: Encodable {
     private enum CodingKeys: String, CodingKey {
         case challenge
         case timeout
-        case rpId
+        case rpID = "rpId"
         case allowCredentials
         case userVerification
     }

--- a/Sources/WebAuthn/Ceremonies/Registration/PublicKeyCredentialCreationOptions.swift
+++ b/Sources/WebAuthn/Ceremonies/Registration/PublicKeyCredentialCreationOptions.swift
@@ -32,7 +32,7 @@ public struct PublicKeyCredentialCreationOptions: Encodable {
     public let user: PublicKeyCredentialUserEntity
 
     /// Contains a name and an identifier for the Relying Party responsible for the request
-    public let relyingParty: PublicKeyCredentialRpEntity
+    public let relyingParty: PublicKeyCredentialRelyingPartyEntity
 
     /// A list of key types and signature algorithms the Relying Party supports. Ordered from most preferred to least
     /// preferred.
@@ -102,9 +102,9 @@ extension Array where Element == PublicKeyCredentialParameters {
 // MARK: - Credential entities
 
 /// From §5.4.2 (https://www.w3.org/TR/webauthn/#sctn-rp-credential-params).
-/// The PublicKeyCredentialRpEntity dictionary is used to supply additional Relying Party attributes when
+/// The PublicKeyCredentialRelyingPartyEntity dictionary is used to supply additional Relying Party attributes when
 /// creating a new credential.
-public struct PublicKeyCredentialRpEntity: Encodable {
+public struct PublicKeyCredentialRelyingPartyEntity: Encodable {
     /// A unique identifier for the Relying Party entity.
     public let id: String
 

--- a/Sources/WebAuthn/WebAuthnManager.swift
+++ b/Sources/WebAuthn/WebAuthnManager.swift
@@ -143,7 +143,7 @@ public struct WebAuthnManager {
         return PublicKeyCredentialRequestOptions(
             challenge: challenge,
             timeout: timeout,
-            rpId: configuration.relyingPartyID,
+            relyingPartyID: configuration.relyingPartyID,
             allowCredentials: allowCredentials,
             userVerification: userVerification
         )

--- a/Tests/WebAuthnTests/Utils/TestModels/TestAuthData.swift
+++ b/Tests/WebAuthnTests/Utils/TestModels/TestAuthData.swift
@@ -17,7 +17,7 @@ import Crypto
 import WebAuthn
 
 struct TestAuthData {
-    var rpIDHash: [UInt8]?
+    var relyingPartyIDHash: [UInt8]?
     var flags: UInt8?
     var counter: [UInt8]?
     var attestedCredData: [UInt8]?
@@ -25,8 +25,8 @@ struct TestAuthData {
 
     var byteArrayRepresentation: [UInt8] {
         var value: [UInt8] = []
-        if let rpIDHash {
-            value += rpIDHash
+        if let relyingPartyIDHash {
+            value += relyingPartyIDHash
         }
         if let flags {
             value += [flags]
@@ -61,7 +61,7 @@ struct TestAuthDataBuilder {
 
     func validMock() -> Self {
         self
-            .rpIDHash(fromRpID: "example.com")
+            .relyingPartyIDHash(fromRelyingPartyID: "example.com")
             .flags(0b11000101)
             .counter([0b00000000, 0b00000000, 0b00000000, 0b00000000])
             .attestedCredData(
@@ -75,23 +75,23 @@ struct TestAuthDataBuilder {
 
     /// Creates a valid authData
     ///
-    /// rpID = "example.com", user
+    /// relyingPartyID = "example.com", user
     /// flags "extension data included", "user verified" and "user present" are set
     /// sign count is set to 0
     /// random extension data is included
     func validAuthenticationMock() -> Self {
         self
-            .rpIDHash(fromRpID: "example.com")
+            .relyingPartyIDHash(fromRelyingPartyID: "example.com")
             .flags(0b10000101)
             .counter([0b00000000, 0b00000000, 0b00000000, 0b00000000])
             .extensions([UInt8](repeating: 0, count: 20))
     }
 
-    func rpIDHash(fromRpID rpID: String) -> Self {
-        let rpIDData = rpID.data(using: .utf8)!
-        let rpIDHash = SHA256.hash(data: rpIDData)
+    func relyingPartyIDHash(fromRelyingPartyID relyingPartyID: String) -> Self {
+        let relyingPartyIDData = relyingPartyID.data(using: .utf8)!
+        let relyingPartyIDHash = SHA256.hash(data: relyingPartyIDData)
         var temp = self
-        temp.wrapped.rpIDHash = [UInt8](rpIDHash)
+        temp.wrapped.relyingPartyIDHash = [UInt8](relyingPartyIDHash)
         return temp
     }
 
@@ -148,7 +148,7 @@ struct TestAuthDataBuilder {
 extension TestAuthData {
     static var valid: Self {
         TestAuthData(
-            rpIDHash: [1],
+            relyingPartyIDHash: [1],
             flags: 1,
             counter: [1],
             attestedCredData: [2],

--- a/Tests/WebAuthnTests/WebAuthnManagerAuthenticationTests.swift
+++ b/Tests/WebAuthnTests/WebAuthnManagerAuthenticationTests.swift
@@ -44,7 +44,7 @@ final class WebAuthnManagerAuthenticationTests: XCTestCase {
 
         XCTAssertEqual(options.challenge, challenge)
         XCTAssertEqual(options.timeout, .seconds(1234))
-        XCTAssertEqual(options.rpId, relyingPartyID)
+        XCTAssertEqual(options.relyingPartyID, relyingPartyID)
         XCTAssertEqual(options.allowCredentials, allowCredentials)
         XCTAssertEqual(options.userVerification, .preferred)
     }

--- a/Tests/WebAuthnTests/WebAuthnManagerAuthenticationTests.swift
+++ b/Tests/WebAuthnTests/WebAuthnManagerAuthenticationTests.swift
@@ -76,7 +76,7 @@ final class WebAuthnManagerAuthenticationTests: XCTestCase {
             finishAuthentication(
                 authenticatorData: TestAuthDataBuilder()
                     .validAuthenticationMock()
-                    .rpIDHash(fromRpID: "wrong-id.org")
+                    .relyingPartyIDHash(fromRelyingPartyID: "wrong-id.org")
                     .build()
                     .byteArrayRepresentation
             ),

--- a/Tests/WebAuthnTests/WebAuthnManagerIntegrationTests.swift
+++ b/Tests/WebAuthnTests/WebAuthnManagerIntegrationTests.swift
@@ -106,7 +106,7 @@ final class WebAuthnManagerIntegrationTests: XCTestCase {
             userVerification: userVerification
         )
 
-        XCTAssertEqual(authenticationOptions.rpId, configuration.relyingPartyID)
+        XCTAssertEqual(authenticationOptions.relyingPartyID, configuration.relyingPartyID)
         XCTAssertEqual(authenticationOptions.timeout, authenticationTimeout)
         XCTAssertEqual(authenticationOptions.challenge, mockChallenge)
         XCTAssertEqual(authenticationOptions.userVerification, userVerification)

--- a/Tests/WebAuthnTests/WebAuthnManagerIntegrationTests.swift
+++ b/Tests/WebAuthnTests/WebAuthnManagerIntegrationTests.swift
@@ -115,7 +115,7 @@ final class WebAuthnManagerIntegrationTests: XCTestCase {
         // Now send `authenticationOptions` to client, which in turn will send the authenticator's response back to us:
         // The following lines reflect what an authenticator normally produces
         let authenticatorData = TestAuthDataBuilder().validAuthenticationMock()
-            .rpIDHash(fromRpID: configuration.relyingPartyID)
+            .relyingPartyIDHash(fromRelyingPartyID: configuration.relyingPartyID)
             .counter([0, 0, 0, 1]) // we authenticated once now, so authenticator likely increments the sign counter
             .build()
             .byteArrayRepresentation

--- a/Tests/WebAuthnTests/WebAuthnManagerRegistrationTests.swift
+++ b/Tests/WebAuthnTests/WebAuthnManagerRegistrationTests.swift
@@ -235,7 +235,7 @@ final class WebAuthnManagerRegistrationTests: XCTestCase {
             await finishRegistration(
                 attestationObject: TestAttestationObjectBuilder()
                     .validMock()
-                    .authData(TestAuthDataBuilder().validMock().rpIDHash(fromRpID: "invalid-id.com"))
+                    .authData(TestAuthDataBuilder().validMock().relyingPartyIDHash(fromRelyingPartyID: "invalid-id.com"))
                     .build()
                     .cborEncoded
             ),


### PR DESCRIPTION
I noticed that the term "relying party" was sometimes spelled out, sometimes not. This PR consistently spells it out, by renaming the following:
- `PublicKeyCredentialRequestOptions.rpId` to `PublicKeyCredentialRequestOptions.relyingPartyID`
- `PublicKeyCredentialRpEntity` to `PublicKeyCredentialRelyingPartyEntity`
- remaining local variables that used `rp` to `relyingParty`