### PR TITLE
Updated minimum deployment to Swift 5.9/macOS 13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.9
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the WebAuthn Swift open source project
@@ -18,7 +18,7 @@ import PackageDescription
 let package = Package(
     name: "webauthn-swift",
     platforms: [
-        .macOS(.v12)
+        .macOS(.v13)
     ],
     products: [
         .library(name: "WebAuthn", targets: ["WebAuthn"])

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG swift_version=5.7
+ARG swift_version=5.9
 ARG ubuntu_version=jammy
 ARG base_image=swift:$swift_version-$ubuntu_version
 FROM $base_image

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -3,16 +3,16 @@ version: "3"
 services:
 
   runtime-setup:
-    image: webauthn-swift:22.04-5.7
+    image: webauthn-swift:22.04-5.9
     build:
       args:
         ubuntu_version: "jammy"
-        swift_version: "5.7"
+        swift_version: "5.9"
 
   test:
-    image: webauthn-swift:22.04-5.7
+    image: webauthn-swift:22.04-5.9
     environment: []
       #- SANITIZER_ARG=--sanitize=thread
 
   shell:
-    image: webauthn-swift:22.04-5.7
+    image: webauthn-swift:22.04-5.9


### PR DESCRIPTION
Updated minimum deployment to Swift 5.9/macOS 13 to support things like Duration and other modern niceties.