### PR TITLE
Migrate `AuthenticatorData`'s `Data` to `[UInt8]`

### DIFF
--- a/Sources/WebAuthn/Ceremonies/Authentication/AuthenticatorAssertionResponse.swift
+++ b/Sources/WebAuthn/Ceremonies/Authentication/AuthenticatorAssertionResponse.swift
@@ -70,18 +70,18 @@ extension AuthenticatorAssertionResponse: Decodable {
 }
 
 struct ParsedAuthenticatorAssertionResponse {
-    let rawClientData: Data
+    let rawClientData: [UInt8]
     let clientData: CollectedClientData
-    let rawAuthenticatorData: Data
+    let rawAuthenticatorData: [UInt8]
     let authenticatorData: AuthenticatorData
     let signature: URLEncodedBase64
     let userHandle: [UInt8]?
 
     init(from authenticatorAssertionResponse: AuthenticatorAssertionResponse) throws {
-        rawClientData = Data(authenticatorAssertionResponse.clientDataJSON)
-        clientData = try JSONDecoder().decode(CollectedClientData.self, from: rawClientData)
+        rawClientData = authenticatorAssertionResponse.clientDataJSON
+        clientData = try JSONDecoder().decode(CollectedClientData.self, from: Data(rawClientData))
 
-        rawAuthenticatorData = Data(authenticatorAssertionResponse.authenticatorData)
+        rawAuthenticatorData = authenticatorAssertionResponse.authenticatorData
         authenticatorData = try AuthenticatorData(bytes: rawAuthenticatorData)
         signature = authenticatorAssertionResponse.signature.base64URLEncodedString()
         userHandle = authenticatorAssertionResponse.userHandle

--- a/Sources/WebAuthn/Ceremonies/Registration/AttestationObject.swift
+++ b/Sources/WebAuthn/Ceremonies/Registration/AttestationObject.swift
@@ -19,7 +19,7 @@ import SwiftCBOR
 /// Contains the cryptographic attestation that a new key pair was created by that authenticator.
 public struct AttestationObject {
     let authenticatorData: AuthenticatorData
-    let rawAuthenticatorData: Data
+    let rawAuthenticatorData: [UInt8]
     let format: AttestationFormat
     let attestationStatement: CBOR
 

--- a/Sources/WebAuthn/Ceremonies/Registration/AuthenticatorAttestationResponse.swift
+++ b/Sources/WebAuthn/Ceremonies/Registration/AuthenticatorAttestationResponse.swift
@@ -75,8 +75,8 @@ struct ParsedAuthenticatorAttestationResponse {
         }
 
         attestationObject = AttestationObject(
-            authenticatorData: try AuthenticatorData(bytes: Data(authDataBytes)),
-            rawAuthenticatorData: Data(authDataBytes),
+            authenticatorData: try AuthenticatorData(bytes: authDataBytes),
+            rawAuthenticatorData: authDataBytes,
             format: attestationFormat,
             attestationStatement: attestationStatement
         )

--- a/Sources/WebAuthn/Ceremonies/Shared/AuthenticatorData.swift
+++ b/Sources/WebAuthn/Ceremonies/Shared/AuthenticatorData.swift
@@ -28,7 +28,7 @@ struct AuthenticatorData: Equatable {
 }
 
 extension AuthenticatorData {
-    init(bytes: Data) throws {
+    init(bytes: [UInt8]) throws {
         let minAuthDataLength = 37
         guard bytes.count >= minAuthDataLength else {
             throw WebAuthnError.authDataTooShort
@@ -82,7 +82,7 @@ extension AuthenticatorData {
     ///
     /// This is assumed to take place after the first 37 bytes of `data`, which is always of fixed size.
     /// - SeeAlso: [WebAuthn Level 3 Editor's Draft §6.5.1. Attested Credential Data]( https://w3c.github.io/webauthn/#sctn-attested-credential-data)
-    private static func parseAttestedData(_ data: Data) throws -> (AttestedCredentialData, Int) {
+    private static func parseAttestedData(_ data: [UInt8]) throws -> (AttestedCredentialData, Int) {
         /// **aaguid** (16): The AAGUID of the authenticator.
         let aaguidLength = 16
         let aaguid = data[37..<(37 + aaguidLength)]  // To byte at index 52
@@ -126,8 +126,8 @@ extension AuthenticatorData {
 class ByteInputStream: CBORInputStream {
     private var slice : ArraySlice<UInt8>
     
-    init(_ slice: Data) {
-        self.slice = Array(slice)[...]
+    init(_ slice: ArraySlice<UInt8>) {
+        self.slice = slice
     }
     
     /// The remaining bytes in the original data buffer.

--- a/Sources/WebAuthn/Ceremonies/Shared/CredentialPublicKey.swift
+++ b/Sources/WebAuthn/Ceremonies/Shared/CredentialPublicKey.swift
@@ -20,7 +20,7 @@ import SwiftCBOR
 protocol PublicKey {
     var algorithm: COSEAlgorithmIdentifier { get }
     /// Verify a signature was signed with the private key corresponding to the public key.
-    func verify(signature: Data, data: Data) throws
+    func verify(signature: some DataProtocol, data: some DataProtocol) throws
 }
 
 enum CredentialPublicKey {
@@ -86,7 +86,7 @@ enum CredentialPublicKey {
     }
 
     /// Verify a signature was signed with the private key corresponding to the provided public key.
-    func verify(signature: Data, data: Data) throws {
+    func verify(signature: some DataProtocol, data: some DataProtocol) throws {
         try key.verify(signature: signature, data: data)
     }
 }
@@ -134,7 +134,7 @@ struct EC2PublicKey: PublicKey {
         yCoordinate = Data(yCoordinateBytes)
     }
 
-    func verify(signature: Data, data: Data) throws {
+    func verify(signature: some DataProtocol, data: some DataProtocol) throws {
         switch algorithm {
         case .algES256:
             let ecdsaSignature = try P256.Signing.ECDSASignature(derRepresentation: signature)
@@ -184,7 +184,7 @@ struct RSAPublicKeyData: PublicKey {
         e = Data(eBytes)
     }
 
-    func verify(signature: Data, data: Data) throws {
+    func verify(signature: some DataProtocol, data: some DataProtocol) throws {
         throw WebAuthnError.unsupported
         // let rsaSignature = _RSA.Signing.RSASignature(derRepresentation: signature)
 
@@ -229,7 +229,7 @@ struct OKPPublicKey: PublicKey {
         xCoordinate = xCoordinateBytes
     }
 
-    func verify(signature: Data, data: Data) throws {
+    func verify(signature: some DataProtocol, data: some DataProtocol) throws {
         throw WebAuthnError.unsupported
     }
 }


### PR DESCRIPTION
Replaced uses of AuthenticatorData Data with [UInt8] to consolidate and minimize type conversions during processing.