### PR TITLE
Unrestrained CBOR Fixes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .library(name: "WebAuthn", targets: ["WebAuthn"])
     ],
     dependencies: [
-        .package(url: "https://github.com/unrelentingtech/SwiftCBOR.git", from: "0.4.5"),
+        .package(url: "https://github.com/unrelentingtech/SwiftCBOR.git", from: "0.4.7"),
         .package(url: "https://github.com/apple/swift-crypto.git", "2.0.0" ..< "4.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.1.0")

--- a/Sources/WebAuthn/Ceremonies/Registration/AuthenticatorAttestationResponse.swift
+++ b/Sources/WebAuthn/Ceremonies/Registration/AuthenticatorAttestationResponse.swift
@@ -56,7 +56,7 @@ struct ParsedAuthenticatorAttestationResponse {
 
         // Step 11. (assembling attestationObject)
         let attestationObjectData = Data(rawResponse.attestationObject)
-        guard let decodedAttestationObject = try? CBOR.decode([UInt8](attestationObjectData)) else {
+        guard let decodedAttestationObject = try? CBOR.decode([UInt8](attestationObjectData), options: CBOROptions(maximumDepth: 16)) else {
             throw WebAuthnError.invalidAttestationObject
         }
 

--- a/Sources/WebAuthn/Ceremonies/Shared/AuthenticatorData.swift
+++ b/Sources/WebAuthn/Ceremonies/Shared/AuthenticatorData.swift
@@ -105,7 +105,7 @@ extension AuthenticatorData {
         /// **credentialPublicKey** (variable): The credential public key encoded in `COSE_Key` format, as defined in [Section 7](https://tools.ietf.org/html/rfc9052#section-7) of [RFC9052], using the CTAP2 canonical CBOR encoding form.
         /// Assuming valid CBOR, verify the public key's length by decoding the next CBOR item.
         let inputStream = ByteInputStream(data[credentialIDEndIndex...])
-        let decoder = CBORDecoder(stream: inputStream)
+        let decoder = CBORDecoder(stream: inputStream, options: CBOROptions(maximumDepth: 16))
         _ = try decoder.decodeItem()
         let publicKeyBytes = data[credentialIDEndIndex..<(data.count - inputStream.remainingBytes)]
 

--- a/Sources/WebAuthn/Ceremonies/Shared/CredentialPublicKey.swift
+++ b/Sources/WebAuthn/Ceremonies/Shared/CredentialPublicKey.swift
@@ -40,7 +40,7 @@ enum CredentialPublicKey {
     }
 
     init(publicKeyBytes: [UInt8]) throws {
-        guard let publicKeyObject = try CBOR.decode(publicKeyBytes) else {
+        guard let publicKeyObject = try CBOR.decode(publicKeyBytes, options: CBOROptions(maximumDepth: 16)) else {
             throw WebAuthnError.badPublicKeyBytes
         }
 

--- a/Tests/WebAuthnTests/WebAuthnManagerRegistrationTests.swift
+++ b/Tests/WebAuthnTests/WebAuthnManagerRegistrationTests.swift
@@ -356,18 +356,14 @@ final class WebAuthnManagerRegistrationTests: XCTestCase {
         XCTAssertEqual(credential.publicKey, credentialPublicKey)
     }
 
-    // Swift CBOR library currently crashes when running this test. WE NEED TO FIX THIS
-    // TODO: Fix this test
-    // func testFinishRegistrationFuzzying() async throws {
-    //     for _ in 1...50 {
-    //         let length = Int.random(in: 1...10_000_000)
-    //         let randomAttestationObject: URLEncodedBase64 = Data(
-    //             [UInt8](repeating: UInt8.random(), count: length)
-    //         ).base64URLEncodedString()
-    //         let shouldBeNil = try? await finishRegistration(attestationObject: randomAttestationObject)
-    //         XCTAssertNil(shouldBeNil)
-    //     }
-    // }
+    func testFinishRegistrationFuzzying() async throws {
+        for _ in 1...50 {
+            let length = Int.random(in: 1...10_000_000)
+            let randomAttestationObject = Array(repeating: UInt8.random(), count: length)
+            let shouldBeNil = try? await finishRegistration(attestationObject: randomAttestationObject)
+            XCTAssertNil(shouldBeNil)
+        }
+    }
 
     private func finishRegistration(
         challenge: [UInt8] = TestConstants.mockChallenge,


### PR DESCRIPTION
Fixed a crash that could occur with un-restrained CBOR data being decoded leading to stack depletion. I picked 16 to be much larger than most of the structures we are typically dealing with (keys and auth data), though we might need to revisit the number when dealing with actual attestations.