### PR TITLE
Support Custom ChallengeGenerator

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/unrelentingtech/SwiftCBOR.git", from: "0.4.7"),
-        .package(url: "https://github.com/apple/swift-crypto.git", "3.8.1" ..< "4.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", "3.8.1" ..< "5.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin.git", from: "1.1.0")
     ],

--- a/Sources/WebAuthn/Helpers/ChallengeGenerator.swift
+++ b/Sources/WebAuthn/Helpers/ChallengeGenerator.swift
@@ -11,10 +11,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-package struct ChallengeGenerator: Sendable {
-    var generate: @Sendable () -> [UInt8]
+public struct ChallengeGenerator: Sendable {
+    public var generate: @Sendable () -> [UInt8]
 
-    package static var live: Self {
+    public init(generate: @Sendable @escaping () -> [UInt8]) {
+        self.generate = generate
+    }
+  
+    public static var live: Self {
         .init(generate: { [UInt8].random(count: 32) })
     }
 }

--- a/Sources/WebAuthn/WebAuthnManager.swift
+++ b/Sources/WebAuthn/WebAuthnManager.swift
@@ -35,11 +35,8 @@ public struct WebAuthnManager: Sendable {
     ///
     /// - Parameters:
     ///   - configuration: The configuration to use for this manager.
-    public init(configuration: Configuration) {
-        self.init(configuration: configuration, challengeGenerator: .live)
-    }
-    
-    package init(configuration: Configuration, challengeGenerator: ChallengeGenerator) {
+    ///   - challengeGenerator: The generator of challenge.
+    public init(configuration: Configuration, challengeGenerator: ChallengeGenerator = .live) {
         self.configuration = configuration
         self.challengeGenerator = challengeGenerator
     }


### PR DESCRIPTION
I want to use secure challenge value.

```swift
let webAuthn = WebAuthnManager(
  configuration: .init(
    relyingPartyID: "RELYING_PARTY_ID",
    relyingPartyName: "RELYING_PARTY_NAME",
    relyingPartyOrigin: "RELYING_PARTY_ORIGIN"
  ),
  challengeGenerator: .init {
    SymmetricKey(size: .bits256).withUnsafeBytes { Array($0) } // 32 bytes
  }
)
```