### PR TITLE
Unsafe Challenge Overrides

### DIFF
--- a/Sources/WebAuthn/Ceremonies/Authentication/PublicKeyCredentialRequestOptions.swift
+++ b/Sources/WebAuthn/Ceremonies/Authentication/PublicKeyCredentialRequestOptions.swift
@@ -21,8 +21,17 @@ import Foundation
 public struct PublicKeyCredentialRequestOptions: Sendable {
     /// A challenge that the authenticator signs, along with other data, when producing an authentication assertion.
     ///
-    /// When encoding using `Encodable` this is encoded as base64url.
-    public var challenge: [UInt8]
+    /// The Relying Party should store the challenge temporarily until the authentication flow is complete. When encoding using `Encodable` this is encoded as base64url.
+    ///
+    /// - Warning: Although the challenge can be changed, doing so is not recommended and can lead to an insecure implementation of the WebAuthn protocol. See ``setUnsafeChallenge(_:)``.
+    public private(set) var challenge: [UInt8]
+
+    /// Unsafely change the challenge that will be delivered to the client.
+    ///
+    /// - Warning: Although the challenge can be changed, doing so is not recommended and can lead to an insecure implementation of the WebAuthn protocol.
+    public mutating func setUnsafeChallenge(_ newValue: [UInt8]) {
+        challenge = newValue
+    }
 
     /// A time, in seconds, that the caller is willing to wait for the call to complete. This is treated as a
     /// hint, and may be overridden by the client.

--- a/Sources/WebAuthn/Ceremonies/Authentication/PublicKeyCredentialRequestOptions.swift
+++ b/Sources/WebAuthn/Ceremonies/Authentication/PublicKeyCredentialRequestOptions.swift
@@ -23,13 +23,13 @@ public struct PublicKeyCredentialRequestOptions: Sendable {
     ///
     /// The Relying Party should store the challenge temporarily until the authentication flow is complete. When encoding using `Encodable` this is encoded as base64url.
     ///
-    /// - Warning: Although the challenge can be changed, doing so is not recommended and can lead to an insecure implementation of the WebAuthn protocol. See ``setUnsafeChallenge(_:)``.
+    /// - SeeAlso: See ``unsafeSetChallenge(_:)`` for updating the challenge.
     public private(set) var challenge: [UInt8]
 
     /// Unsafely change the challenge that will be delivered to the client.
     ///
     /// - Warning: Although the challenge can be changed, doing so is not recommended and can lead to an insecure implementation of the WebAuthn protocol.
-    public mutating func setUnsafeChallenge(_ newValue: [UInt8]) {
+    public mutating func unsafeSetChallenge(_ newValue: [UInt8]) {
         challenge = newValue
     }
 

--- a/Sources/WebAuthn/Ceremonies/Registration/PublicKeyCredentialCreationOptions.swift
+++ b/Sources/WebAuthn/Ceremonies/Registration/PublicKeyCredentialCreationOptions.swift
@@ -26,13 +26,13 @@ public struct PublicKeyCredentialCreationOptions: Sendable {
     /// The Relying Party should store the challenge temporarily until the registration flow is complete. When
     /// encoding using `Encodable`, the challenge is base64url encoded.
     ///
-    /// - Warning: Although the challenge can be changed, dooing so is not recommended and can lead to an insecure implementation of the WebAuthn protocol. See ``setUnsafeChallenge(_:)``.
+    /// - SeeAlso: See ``unsafeSetChallenge(_:)`` for updating the challenge.
     public private(set) var challenge: [UInt8]
     
     /// Unsafely change the challenge that will be delivered to the client.
     ///
     /// - Warning: Although the challenge can be changed, doing so is not recommended and can lead to an insecure implementation of the WebAuthn protocol.
-    public mutating func setUnsafeChallenge(_ newValue: [UInt8]) {
+    public mutating func unsafeSetChallenge(_ newValue: [UInt8]) {
         challenge = newValue
     }
 

--- a/Sources/WebAuthn/Ceremonies/Registration/PublicKeyCredentialCreationOptions.swift
+++ b/Sources/WebAuthn/Ceremonies/Registration/PublicKeyCredentialCreationOptions.swift
@@ -25,7 +25,16 @@ public struct PublicKeyCredentialCreationOptions: Sendable {
     ///
     /// The Relying Party should store the challenge temporarily until the registration flow is complete. When
     /// encoding using `Encodable`, the challenge is base64url encoded.
-    public let challenge: [UInt8]
+    ///
+    /// - Warning: Although the challenge can be changed, dooing so is not recommended and can lead to an insecure implementation of the WebAuthn protocol. See ``setUnsafeChallenge(_:)``.
+    public private(set) var challenge: [UInt8]
+    
+    /// Unsafely change the challenge that will be delivered to the client.
+    ///
+    /// - Warning: Although the challenge can be changed, doing so is not recommended and can lead to an insecure implementation of the WebAuthn protocol.
+    public mutating func setUnsafeChallenge(_ newValue: [UInt8]) {
+        challenge = newValue
+    }
 
     /// Contains names and an identifier for the user account performing the registration.
     public var user: PublicKeyCredentialUserEntity


### PR DESCRIPTION
I'm still unclear _why_ folks would want to change how challenges are generated, but this change let's them do so with the appropriate warnings in place by adding unsafe setters for changing the challenge returned by the manager. Closes #72