### PR TITLE
Added AAGUID accessor to Credential and AttestationObject structs

### DIFF
--- a/Sources/WebAuthn/Ceremonies/Registration/AttestationObject.swift
+++ b/Sources/WebAuthn/Ceremonies/Registration/AttestationObject.swift
@@ -22,6 +22,13 @@ public struct AttestationObject: Sendable {
     let format: AttestationFormat
     let attestationStatement: CBOR
 
+    /// The Authenticator Attestation Globally Unique Identifier (AAGUID) from the attestation object.
+    /// Returns nil if attested credential data is not present.
+    /// - SeeAlso: [WebAuthn Level 3 Editor's Draft §6.5.1. Attested Credential Data](https://w3c.github.io/webauthn/#sctn-attested-credential-data)
+    public var aaguid: AAGUID? {
+        authenticatorData.attestedData?.authenticatorAttestationGUID
+    }
+
     func verify(
         relyingPartyID: String,
         verificationRequired: Bool,

--- a/Sources/WebAuthn/Ceremonies/Registration/Credential.swift
+++ b/Sources/WebAuthn/Ceremonies/Registration/Credential.swift
@@ -43,4 +43,11 @@ public struct Credential: Sendable {
     public let attestationObject: AttestationObject
 
     public let attestationClientDataJSON: CollectedClientData
+
+    /// The Authenticator Attestation Globally Unique Identifier (AAGUID) from the attestation object.
+    /// Returns nil if attested credential data is not present.
+    /// - SeeAlso: [WebAuthn Level 3 Editor's Draft §6.5.1. Attested Credential Data](https://w3c.github.io/webauthn/#sctn-attested-credential-data)
+    public var aaguid: AAGUID? {
+        attestationObject.aaguid
+    }
 }


### PR DESCRIPTION
The purpose of adding `aaguid` accessors is to allow a server to map the ID to a provider name using tables like those on https://github.com/passkeydeveloper/passkey-authenticator-aaguids.