### PR TITLE
Added public init methods necessary for the registration ceremony.

### DIFF
--- a/Sources/WebAuthn/Ceremonies/Authentication/AuthenticationCredential.swift
+++ b/Sources/WebAuthn/Ceremonies/Authentication/AuthenticationCredential.swift
@@ -32,6 +32,14 @@ public struct AuthenticationCredential: Sendable {
 
     /// Value will always be ``CredentialType/publicKey`` (for now)
     public let type: CredentialType
+    
+	public init(id: URLEncodedBase64, rawID: [UInt8], response: AuthenticatorAssertionResponse, authenticatorAttachment: AuthenticatorAttachment?, type: CredentialType) {
+		self.id = id
+		self.rawID = rawID
+		self.response = response
+		self.authenticatorAttachment = authenticatorAttachment
+		self.type = type
+	}
 }
 
 extension AuthenticationCredential: Codable {

--- a/Sources/WebAuthn/Ceremonies/Authentication/AuthenticatorAssertionResponse.swift
+++ b/Sources/WebAuthn/Ceremonies/Authentication/AuthenticatorAssertionResponse.swift
@@ -46,6 +46,14 @@ public struct AuthenticatorAssertionResponse: Sendable {
     ///
     /// When decoding using `Decodable`, this is decoded from base64url to bytes.
     public let attestationObject: [UInt8]?
+    
+	public init(clientDataJSON: [UInt8], authenticatorData: [UInt8], signature: [UInt8], userHandle: [UInt8]?, attestationObject: [UInt8]?) {
+		self.clientDataJSON = clientDataJSON
+		self.authenticatorData = authenticatorData
+		self.signature = signature
+		self.userHandle = userHandle
+		self.attestationObject = attestationObject
+	}
 }
 
 extension AuthenticatorAssertionResponse: Codable {

--- a/Sources/WebAuthn/Ceremonies/Registration/AuthenticatorAttestationResponse.swift
+++ b/Sources/WebAuthn/Ceremonies/Registration/AuthenticatorAttestationResponse.swift
@@ -27,6 +27,11 @@ public struct AuthenticatorAttestationResponse: Sendable {
     ///
     /// When decoding using `Decodable`, this is decoded from base64url to bytes.
     public let attestationObject: [UInt8]
+    
+	public init(clientDataJSON: [UInt8], attestationObject: [UInt8]) {
+		self.clientDataJSON = clientDataJSON
+		self.attestationObject = attestationObject
+	}
 }
 
 extension AuthenticatorAttestationResponse: Codable {

--- a/Sources/WebAuthn/Ceremonies/Registration/RegistrationCredential.swift
+++ b/Sources/WebAuthn/Ceremonies/Registration/RegistrationCredential.swift
@@ -29,6 +29,13 @@ public struct RegistrationCredential: Sendable {
 
     /// The attestation response from the authenticator.
     public let attestationResponse: AuthenticatorAttestationResponse
+    
+	public init(id: URLEncodedBase64, type: CredentialType, rawID: [UInt8], attestationResponse: AuthenticatorAttestationResponse) {
+		self.id = id
+		self.type = type
+		self.rawID = rawID
+		self.attestationResponse = attestationResponse
+	}
 }
 
 extension RegistrationCredential: Codable {


### PR DESCRIPTION
From within my Swift Vapor REST API handlers, I don't have an easy Decodable to hand to the initializers for handling auth and registration. This PR adds public memberwise initializers to `AuthenticationCredential`, `AuthenticatorAssertionResponse`, `AuthenticatorAttestationResponse`, and `RegistrationCredential`.