### PR TITLE
Expose public initializers for Credential and VerifiedAuthentication

### DIFF
--- a/Sources/WebAuthn/Ceremonies/Authentication/VerifiedAuthentication.swift
+++ b/Sources/WebAuthn/Ceremonies/Authentication/VerifiedAuthentication.swift
@@ -38,4 +38,16 @@ public struct VerifiedAuthentication: Sendable {
     public let credentialDeviceType: CredentialDeviceType
     /// Whether the authenticator is known to be backed up currently
     public let credentialBackedUp: Bool
+
+    public init(
+        credentialID: URLEncodedBase64,
+        newSignCount: UInt32,
+        credentialDeviceType: CredentialDeviceType,
+        credentialBackedUp: Bool
+    ) {
+        self.credentialID = credentialID
+        self.newSignCount = newSignCount
+        self.credentialDeviceType = credentialDeviceType
+        self.credentialBackedUp = credentialBackedUp
+    }
 }

--- a/Sources/WebAuthn/Ceremonies/Registration/Credential.swift
+++ b/Sources/WebAuthn/Ceremonies/Registration/Credential.swift
@@ -48,6 +48,26 @@ public struct Credential: Sendable {
 
     public let attestationClientDataJSON: CollectedClientData
 
+    public init(
+        type: CredentialType,
+        id: String,
+        publicKey: [UInt8],
+        signCount: UInt32,
+        backupEligible: Bool,
+        isBackedUp: Bool,
+        attestationObject: AttestationObject,
+        attestationClientDataJSON: CollectedClientData
+    ) {
+        self.type = type
+        self.id = id
+        self.publicKey = publicKey
+        self.signCount = signCount
+        self.backupEligible = backupEligible
+        self.isBackedUp = isBackedUp
+        self.attestationObject = attestationObject
+        self.attestationClientDataJSON = attestationClientDataJSON
+    }
+
     /// The Authenticator Attestation Globally Unique Identifier (AAGUID) from the attestation object.
     /// Returns nil if attested credential data is not present.
     /// - SeeAlso: [WebAuthn Level 3 Editor's Draft §6.5.1. Attested Credential Data](https://w3c.github.io/webauthn/#sctn-attested-credential-data)

--- a/Tests/WebAuthnTests/AuthenticatorSelectionTests.swift
+++ b/Tests/WebAuthnTests/AuthenticatorSelectionTests.swift
@@ -21,8 +21,6 @@ import Testing
 
 struct AuthenticatorSelectionTests {
 
-    /// Minimal representation of an encoded ``AuthenticatorSelection`` used to inspect JSON output
-    /// without relying on `JSONSerialization`, which is unavailable in `FoundationEssentials`.
     private struct EncodedAuthenticatorSelection: Decodable {
         let residentKey: String?
         let requireResidentKey: Bool?

--- a/Tests/WebAuthnTests/AuthenticatorSelectionTests.swift
+++ b/Tests/WebAuthnTests/AuthenticatorSelectionTests.swift
@@ -20,7 +20,14 @@ import Testing
 @testable import WebAuthn
 
 struct AuthenticatorSelectionTests {
-    
+
+    /// Minimal representation of an encoded ``AuthenticatorSelection`` used to inspect JSON output
+    /// without relying on `JSONSerialization`, which is unavailable in `FoundationEssentials`.
+    private struct EncodedAuthenticatorSelection: Decodable {
+        let residentKey: String?
+        let requireResidentKey: Bool?
+    }
+
     // MARK: - ResidentKeyRequirement Tests
     
     @Test
@@ -120,11 +127,11 @@ struct AuthenticatorSelectionTests {
         )
         
         let json = try JSONEncoder().encode(selection)
-        let jsonObject = try JSONSerialization.jsonObject(with: json) as! [String: Any]
-        
+        let jsonObject = try JSONDecoder().decode(EncodedAuthenticatorSelection.self, from: json)
+
         // When residentKey is .required, requireResidentKey should be true
-        #expect(jsonObject["residentKey"] as? String == "required")
-        #expect(jsonObject["requireResidentKey"] as? Bool == true)
+        #expect(jsonObject.residentKey == "required")
+        #expect(jsonObject.requireResidentKey == true)
     }
     
     @Test
@@ -134,11 +141,11 @@ struct AuthenticatorSelectionTests {
         )
         
         let json = try JSONEncoder().encode(selection)
-        let jsonObject = try JSONSerialization.jsonObject(with: json) as! [String: Any]
-        
+        let jsonObject = try JSONDecoder().decode(EncodedAuthenticatorSelection.self, from: json)
+
         // When residentKey is not .required, requireResidentKey should be false
-        #expect(jsonObject["residentKey"] as? String == "preferred")
-        #expect(jsonObject["requireResidentKey"] as? Bool == false)
+        #expect(jsonObject.residentKey == "preferred")
+        #expect(jsonObject.requireResidentKey == false)
     }
     
     @Test
@@ -146,11 +153,11 @@ struct AuthenticatorSelectionTests {
         let selection = AuthenticatorSelection()
         
         let json = try JSONEncoder().encode(selection)
-        let jsonObject = try JSONSerialization.jsonObject(with: json) as! [String: Any]
-        
+        let jsonObject = try JSONDecoder().decode(EncodedAuthenticatorSelection.self, from: json)
+
         // When residentKey is nil, requireResidentKey should be false
-        #expect(jsonObject["residentKey"] == nil)
-        #expect(jsonObject["requireResidentKey"] as? Bool == false)
+        #expect(jsonObject.residentKey == nil)
+        #expect(jsonObject.requireResidentKey == false)
     }
     
     @Test


### PR DESCRIPTION
## Summary

- Add public memberwise-style initializers for `Credential` and `VerifiedAuthentication`
- Add public API coverage to ensure the new initializers are available through a normal `import WebAuthn`

## Motivation

Downstream applications that wrap `WebAuthnManager` behind a protocol need to construct the same return values in test doubles without introducing adapter-specific result structs.

Fixes #124